### PR TITLE
Bulk MARC import bot updates

### DIFF
--- a/ia-bulkmarc-bot/bulk-import.py
+++ b/ia-bulkmarc-bot/bulk-import.py
@@ -77,6 +77,9 @@ if __name__ == '__main__':
             break
         identifier = '{}/{}:{}:{}'.format(item, fname, offset, length)
         data = {'identifier': identifier, 'bulk_marc': 'true'}
+        if barcode and barcode is not True:
+            # A local_id key has been passed to import a specific local_id barcode
+            data['local_id'] = barcode
         r = ol.session.post(ol.base_url + BULK_API + '?debug=true', data=data)
         try:
             result = r.json()

--- a/ia-bulkmarc-bot/bulk-import.py
+++ b/ia-bulkmarc-bot/bulk-import.py
@@ -18,9 +18,10 @@ from olclient.openlibrary import OpenLibrary
 
 BULK_API = '/api/import/ia'
 LOCAL_ID = re.compile(r'\/local_ids\/(\w+)')
+MARC_EXT = re.compile(r'.*\.(mrc|utf8)$')
 
 def get_marc21_files(item):
-    return [f.name for f in ia.get_files(item) if f.name.endswith('.mrc')]
+    return [f.name for f in ia.get_files(item) if MARC_EXT.match(f.name)]
 
 
 if __name__ == '__main__':
@@ -63,8 +64,8 @@ if __name__ == '__main__':
             print('Item %s has the following MARC files:' % item)
             for f in get_marc21_files(item):
                 print(f)
+        ol.session.close()
         exit()
-
 
     limit = args.number  # if non-zero, a limit to only process this many records from each file
     count = 0

--- a/ia-bulkmarc-bot/bulk-import.py
+++ b/ia-bulkmarc-bot/bulk-import.py
@@ -17,7 +17,7 @@ from olclient.openlibrary import OpenLibrary
 
 
 BULK_API = '/api/import/ia'
-
+LOCAL_ID = re.compile(r'\/local_ids\/(\w+)')
 
 def get_marc21_files(item):
     return [f.name for f in ia.get_files(item) if f.name.endswith('.mrc')]
@@ -25,8 +25,9 @@ def get_marc21_files(item):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Bulk MARC importer.')
-    parser.add_argument('item', help='Source item containing MARC records')
+    parser.add_argument('item', help='Source item containing MARC records', nargs='?')
     parser.add_argument('-i', '--info', help='List available MARC21 .mrc files on this item', action='store_true')
+    parser.add_argument('-b', '--barcode', help='Barcoded local_id available for import', nargs='?', const=True, default=False)
     parser.add_argument('-f', '--file', help='Bulk MARC file to import')
     parser.add_argument('-n', '--number', help='Number of records to import', type=int, default=1)
     parser.add_argument('-o', '--offset', help='Offset in BYTES from which to start importing', type=int, default=0)
@@ -36,13 +37,7 @@ if __name__ == '__main__':
     item = args.item
     fname = args.file
     local_testing = args.local
-
-    if args.info:
-        # List MARC21 files, then quit.
-        print('Item %s has the following MARC files:' % item)
-        for f in get_marc21_files(item):
-            print(f)
-        exit()
+    barcode = args.barcode
 
     if local_testing:
         Credentials = namedtuple('Credentials', ['username', 'password'])
@@ -54,7 +49,22 @@ if __name__ == '__main__':
         #ol = OpenLibrary(base_url='https://dev.openlibrary.org')
 
     print('Importing to %s' % ol.base_url)
+    print('ITEM: %s' % item)
     print('FILENAME: %s' % fname)
+
+    if args.info:
+        if barcode is True:
+            # display available local_ids
+            print('Available local_ids to import:')
+            r = ol.session.get(ol.base_url + '/local_ids.json')
+            print(LOCAL_ID.findall(r.json()['body']['value']))
+        if item:
+            # List MARC21 files, then quit.
+            print('Item %s has the following MARC files:' % item)
+            for f in get_marc21_files(item):
+                print(f)
+        exit()
+
 
     limit = args.number  # if non-zero, a limit to only process this many records from each file
     count = 0

--- a/ia-bulkmarc-bot/bulk-import.py
+++ b/ia-bulkmarc-bot/bulk-import.py
@@ -33,11 +33,13 @@ if __name__ == '__main__':
     parser.add_argument('-n', '--number', help='Number of records to import', type=int, default=1)
     parser.add_argument('-o', '--offset', help='Offset in BYTES from which to start importing', type=int, default=0)
     parser.add_argument('-l', '--local', help='Import to a locally running Open Library dev instance for testing (localhost:8080)', action='store_true')
+    parser.add_argument('-d', '--dev', help='Import to dev.openlibrary.org Open Library dev instance for testing', action='store_true')
 
     args = parser.parse_args()
     item = args.item
     fname = args.file
     local_testing = args.local
+    dev_testing = args.dev
     barcode = args.barcode
 
     if local_testing:
@@ -45,9 +47,10 @@ if __name__ == '__main__':
         local_dev = 'http://localhost:8080'
         c = Credentials('openlibrary@example.com', 'admin123')
         ol = OpenLibrary(base_url=local_dev, credentials=c)
+    elif dev_testing:
+        ol = OpenLibrary(base_url='https://dev.openlibrary.org')
     else:
         ol = OpenLibrary()
-        #ol = OpenLibrary(base_url='https://dev.openlibrary.org')
 
     print('Importing to %s' % ol.base_url)
     print('ITEM: %s' % item)

--- a/ia-bulkmarc-bot/bulk-import.py
+++ b/ia-bulkmarc-bot/bulk-import.py
@@ -12,49 +12,52 @@
 import argparse
 import internetarchive as ia
 import re
-import sys
 from collections import namedtuple
 from olclient.openlibrary import OpenLibrary
 
-LIVE = True  # False to test against a local dev OL instance
-BULK_API = '/api/import/ia'
 
-Credentials = namedtuple('Credentials', ['username', 'password'])
+BULK_API = '/api/import/ia'
 
 
 def get_marc21_files(item):
     return [f.name for f in ia.get_files(item) if f.name.endswith('.mrc')]
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Bulk MARC importer.')
     parser.add_argument('item', help='Source item containing MARC records')
     parser.add_argument('-i', '--info', help='List available MARC21 .mrc files on this item', action='store_true')
     parser.add_argument('-f', '--file', help='Bulk MARC file to import')
-    parser.add_argument('-l', '--limit', help='Number of records to import', type=int, default=1)
+    parser.add_argument('-n', '--number', help='Number of records to import', type=int, default=1)
     parser.add_argument('-o', '--offset', help='Offset in BYTES from which to start importing', type=int, default=0)
+    parser.add_argument('-l', '--local', help='Import to a locally running Open Library dev instance for testing (localhost:8080)', action='store_true')
 
     args = parser.parse_args()
     item = args.item
     fname = args.file
+    local_testing = args.local
 
     if args.info:
         # List MARC21 files, then quit.
+        print('Item %s has the following MARC files:' % item)
         for f in get_marc21_files(item):
             print(f)
         exit()
 
-    if LIVE:
-        ol = OpenLibrary()
-        #ol = OpenLibrary(base_url='https://dev.openlibrary.org')
-    else:
+    if local_testing:
+        Credentials = namedtuple('Credentials', ['username', 'password'])
         local_dev = 'http://localhost:8080'
         c = Credentials('openlibrary@example.com', 'admin123')
         ol = OpenLibrary(base_url=local_dev, credentials=c)
+    else:
+        ol = OpenLibrary()
+        #ol = OpenLibrary(base_url='https://dev.openlibrary.org')
 
-    limit = args.limit  # if non-zero, a limit to only process this many records from each file
-    count = 0
-
+    print('Importing to %s' % ol.base_url)
     print('FILENAME: %s' % fname)
+
+    limit = args.number  # if non-zero, a limit to only process this many records from each file
+    count = 0
     offset = args.offset
     length = 5  # we only need to get the length of the first record (first 5 bytes), the API will seek to the end.
 


### PR DESCRIPTION
## Description:
In this Pull Request we have made the following changes:
* Allows the bot to import to a locally running dev instance of Open Library
* Enables local_id barcode bulk imports into Open Library (using keys from https://openlibrary.org/local_ids) to provide library metadata for physical items by scanning library barcodes.
* More info retrieval from `--info` on item's available MARC files, and system `local_ids`
* Expand MARC filename recognition to include LOC's `.utf8` extension to prepare for impoerting the latest publicly available LOC dumps ([2016](https://archive.org/details/marc_loc_2016)). The last set imported into OL were from [2008](https://archive.org/details/marc_loc_updates).