### PR TITLE
IA sync bot

### DIFF
--- a/ia-sync-bot/.gitignore
+++ b/ia-sync-bot/.gitignore
@@ -1,0 +1,3 @@
+ol_dump_editions_latest.*
+*.lst
+*.txt

--- a/ia-sync-bot/README.md
+++ b/ia-sync-bot/README.md
@@ -21,7 +21,7 @@ BAD-ISBN:       u'0000000002'   OL25422504M     OL16800386W
 ```
 
 ## legacy-openlibrary-id-check.sh
-collects data from https://archive.org and https://openlibrary.org and creates lists and stats on archive.org
+Collects data from https://archive.org and https://openlibrary.org and creates lists and stats for
 items that have old-style `openlibrary` IDs, but no `openlibrary-edition`
 
 ## update-ocaid.py

--- a/ia-sync-bot/README.md
+++ b/ia-sync-bot/README.md
@@ -1,0 +1,18 @@
+#IA Sync Bot
+
+
+
+##extract-isbn.py
+
+Takes an Open Library edition dump as input and outputs tsv of:
+
+<ISBN13> <Edition-OLID> (<Work-OLID> | NONE)
+  OR
+'BAD-ISBN:' <bad isbn> <Edition-OLID> (<Work-OLID> | NONE)
+
+if the isbn does not validate.
+
+Examples:
+9780107805401   OL10000135M     OL7925046W
+BAD-ISBN:       u'0000000002'   OL25422504M     OL16800386W
+

--- a/ia-sync-bot/README.md
+++ b/ia-sync-bot/README.md
@@ -1,18 +1,28 @@
-#IA Sync Bot
+# IA Sync Bot
 
 
 
-##extract-isbn.py
+## extract-isbn.py
 
 Takes an Open Library edition dump as input and outputs tsv of:
 
-<ISBN13> <Edition-OLID> (<Work-OLID> | NONE)
+`<ISBN13> <Edition-OLID> (<Work-OLID> | 'NONE')`
+
   OR
-'BAD-ISBN:' <bad isbn> <Edition-OLID> (<Work-OLID> | NONE)
+  
+`'BAD-ISBN:' <bad isbn> <Edition-OLID> (<Work-OLID> | 'NONE')`
 
 if the isbn does not validate.
 
 Examples:
+```
 9780107805401   OL10000135M     OL7925046W
 BAD-ISBN:       u'0000000002'   OL25422504M     OL16800386W
+```
 
+## legacy-openlibrary-id-check.sh
+collects data from https://archive.org and https://openlibrary.org and creates lists and stats on archive.org
+items that have old-style `openlibrary` IDs, but no `openlibrary-edition`
+
+## update-ocaid.py
+Takes results of archive.org json search results and writes ocaids to Open Library items, and performs a sync.

--- a/ia-sync-bot/extract-isbn.py
+++ b/ia-sync-bot/extract-isbn.py
@@ -1,0 +1,53 @@
+#!/usr/bin/python
+
+import isbnlib
+import json
+import sys
+
+# Extracts ISBN_13 OLID W-WOLID from openlibrary edition data dumps.
+#
+# Takes an Open Library edition dump as input and outputs tsv of:
+#
+# <ISBN13> <Edition-OLID> (<Work-OLID> | NONE)
+#   OR
+# 'BAD-ISBN:' <bad isbn> <Edition-OLID> (<Work-OLID> | NONE)
+# if the isbn does not validate.
+#
+
+infile = "/storage/openlibrary/ol_dump_editions_2018-06-30.txt"
+infile = sys.argv[1] 
+
+with open(infile) as f:
+    for line in f:
+        data = line.split("\t")
+        book = json.loads(data[4])
+        olid = book.get('key').replace('/books/', '')
+        wolid = book.get('works', 'NONE')
+        if wolid != 'NONE':
+           wolid = wolid[0]['key'].replace('/works/', '')
+
+        # get isbn
+        good_isbn = []
+        bad_isbn = []
+        isbn_13 = book.get('isbn_13', [])
+        isbn_10 = book.get('isbn_10', [])
+        for isbn in isbn_13 + isbn_10:
+            canonical = isbnlib.get_canonical_isbn(isbn)
+            if canonical: 
+                if len(canonical) == 10:
+                    canonical = isbnlib.to_isbn13(canonical)
+                good_isbn.append(canonical)
+            else:
+                bad_isbn.append(isbn)
+
+        isbns = set(good_isbn)
+        for isbn in isbns:
+            try:
+                assert isbnlib.get_canonical_isbn(isbn)
+                print("\t".join([isbnlib.get_canonical_isbn(isbn), olid, wolid]))
+            except Exception as e:
+                bad_isbn.append(isbn)
+
+        for bad in bad_isbn:
+            print(u"\t".join([u'BAD-ISBN:', repr(bad), olid, wolid]))
+

--- a/ia-sync-bot/legacy-openlibrary-id-check.sh
+++ b/ia-sync-bot/legacy-openlibrary-id-check.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Some Archive.org items have old-style `openlibrary` IDs, and no `openlibrary-edition`.
+# Many of these OL editions don't have `ocaid`
+#    https://github.com/internetarchive/openlibrary/issues/1046
+# This scripts collects data from archive.org and openlibrary.org and creates lists and stats
+# for the various categories.
+
+
+# Test for Open Library edition dump file in current dir:
+
+ol_dump="ol_dump_editions_latest.txt"
+
+if [ ! -f "$ol_dump" ]; then
+  echo ""
+  echo "Open Library Editions dump file '$ol_dump' not found!"
+  echo "Please download and extract it to the current directory by running the following commands:"
+  echo "  wget https://openlibrary.org/data/ol_dump_editions_latest.txt.gz"
+  echo "  gunzip ol_dump_editions_latest.txt.gz"
+  exit 1
+fi
+
+# Get IA items with only legacy field:
+echo " Getting list of archive.org items with only a legacy openlibrary field..."
+ia search "openlibrary:* AND NOT openlibrary_edition:*" -f"openlibrary" > legacy-openlibrary-field.txt
+
+# Extract OLIDs
+egrep -o "OL[0-9]+M" legacy-openlibrary-field.txt > legacy-linked-olids.lst
+
+# Get data of all uniq editions referenced by archive.org items with only legacy openlibrary field:
+grep -Ff legacy-linked-olids.lst $ol_dump > legacy-linked-dump.txt
+
+# Count of uniq editions referenced by archive.org items with only legacy openlibrary field.
+legacy_linked=$(wc -l legacy-linked-dump.txt)
+
+# How many of these are orphans?
+orphans=$(grep -vc '"works":' legacy-linked-dump.txt)
+
+# How many already have ocaids?
+have_ocaid=$(grep -c '"ocaid"' legacy-linked-dump.txt)
+
+# How many don't have ocaids:
+no_ocaid=$(grep -vc '"ocaid"' legacy-linked-dump.txt)
+
+
+echo "Report $(date):"
+echo "Uniq editions referenced by archive.org items with only legacy openlibrary field"
+echo " Total: $legacy_linked"
+echo " Orphans: $orphans"
+echo " No OCAID: $no_ocaid"
+

--- a/ia-sync-bot/requirements.txt
+++ b/ia-sync-bot/requirements.txt
@@ -1,0 +1,1 @@
+isbnlib

--- a/ia-sync-bot/requirements.txt
+++ b/ia-sync-bot/requirements.txt
@@ -1,1 +1,2 @@
 isbnlib
+openlibrary-client

--- a/ia-sync-bot/update-ocaid.py
+++ b/ia-sync-bot/update-ocaid.py
@@ -1,0 +1,46 @@
+#!/usr/bin/python
+import json
+from olclient.openlibrary import OpenLibrary
+ol = OpenLibrary()
+
+infile = "olids-to-update.txt"
+
+# infile is the json output of an archive.org search query
+# containing an 'openlibrary' (edition olid) and 'identifier' (ocaid) fields
+
+
+def sync_ol_to_ia(olid):
+    r = ol.session.get(ol.base_url + "/admin/sync?edition_id=" + olid)
+    if 'error' in r.json() and r.json()['error'] == 'No qualifying edition':
+        print("%s, %s: %s" % (olid, ocaid, r.json()))
+
+start = 187
+start = 7649
+end = False
+with open(infile) as f:
+   for count, line in enumerate(f):
+       # OLD TSV FORMAT: ocaid, olid = line.split()
+       data = json.loads(line)
+       ocaid = data.get('identifier')
+       olid  = data.get('openlibrary')
+       if start and count < start:
+           continue
+       if end and count > end:
+           break
+       # check and add ocaid to OL edition
+       print "Adding %s to %s" % (ocaid, olid)
+       edition = ol.get(olid)
+       #while not hasattr(edition, 'title')
+       try:
+           assert edition.title
+       except:
+           print "]%s[" % olid
+           break
+
+       if hasattr(edition, 'ocaid'):
+           print("  OCAID already found: %s" % edition.ocaid)
+       else:
+           edition.ocaid = ocaid
+           edition.save('add ocaid') 
+       # sync the edition
+       sync_ol_to_ia(olid)

--- a/ia-sync-bot/update-ocaid.py
+++ b/ia-sync-bot/update-ocaid.py
@@ -5,8 +5,10 @@ ol = OpenLibrary()
 
 infile = "olids-to-update.txt"
 
+# Takes an infile and writes ocaids to Open Library items and performs a sync.
+
 # infile is the json output of an archive.org search query
-# containing an 'openlibrary' (edition olid) and 'identifier' (ocaid) fields
+# containing 'openlibrary' (edition olid) and 'identifier' (ocaid) fields
 
 
 def sync_ol_to_ia(olid):
@@ -14,8 +16,9 @@ def sync_ol_to_ia(olid):
     if 'error' in r.json() and r.json()['error'] == 'No qualifying edition':
         print("%s, %s: %s" % (olid, ocaid, r.json()))
 
-start = 187
-start = 7649
+# start and end are False or line numbers in infile to begin and stop processing
+# Used in case there is a need to resume or re-run part of a batch.
+start = False
 end = False
 with open(infile) as f:
    for count, line in enumerate(f):

--- a/ia-sync-bot/update-ocaid.py
+++ b/ia-sync-bot/update-ocaid.py
@@ -38,12 +38,7 @@ with open(infile) as f:
        # check and add ocaid to OL edition
        print("Adding %s to %s" % (ocaid, olid))
        edition = ol.get(olid)
-       #while not hasattr(edition, 'title')
-       try:
-           assert edition.title
-       except:
-           print("]%s[" % olid)
-           break
+       assert edition.title, "Missing title in %s!" % olid
 
        if hasattr(edition, 'ocaid'):
            print("  OCAID already found: %s" % edition.ocaid)


### PR DESCRIPTION
This code helps resolve and is referenced by https://github.com/internetarchive/openlibrary/issues/1046

## Description:
In this Pull Request we have made the following changes:
* Various scripts to check and sync archive.org and Open Library identifiers between the two systems

This is somewhat old code, but it was useful to sync up a large gap in identifiers, see https://github.com/internetarchive/openlibrary/issues/1046  and the sync project wiki page https://github.com/internetarchive/openlibrary/wiki/archive.org-%E2%86%94-Open-Library-synchronisation

This code is possibly only useful as a historical record now that the sync processes are better.

Making the PR as the code only existed on my personal fork.