### PR TITLE
Add a pytest to get our automated testing started

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -18,4 +18,4 @@ jobs:
       - run: pip list --outdated
       - run: pip install -e .  # https://docs.pytest.org/en/stable/goodpractices.html
       - run: pytest .
-      - run: pytest --doctest-modules . || true
+      # - run: pytest --doctest-modules . || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -2,7 +2,7 @@ name: lint_python
 on:
   pull_request:
   push:
-  #  branches: [master]
+    branches: [master]
 jobs:
   lint_python:
     runs-on: ubuntu-latest
@@ -22,6 +22,6 @@ jobs:
       #    black --check .
       - run: codespell --quiet-level=2 || true  # --ignore-words-list="" --skip=""
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-      - run: isort --recursive . || true
-      - run: pip install -r requirements.txt || true
-      - run: pytest . || true
+      - run: isort --profile black . || true
+      - run: pip install -r requirements.txt
+      - run: pytest .

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -24,4 +24,6 @@ jobs:
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
       - run: isort --profile black . || true
       - run: pip install -r requirements.txt
+      - run: pip list --outdated
+      - run: pip install -e .  # https://docs.pytest.org/en/stable/goodpractices.html
       - run: pytest .

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -11,8 +11,8 @@ jobs:
     #    os: [ubuntu-latest, macos-latest, windows-latest]
     #    python-version: [2.7, 3.5, 3.6, 3.7, 3.8]  # , pypy3]
     steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-python@master
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
       - run: pip install black codespell flake8 isort pytest
       - run: black --check . || true
       # - run: black --diff . || true
@@ -27,3 +27,4 @@ jobs:
       - run: pip list --outdated
       - run: pip install -e .  # https://docs.pytest.org/en/stable/goodpractices.html
       - run: pytest .
+      - run: pytest --doctest-modules . || true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+isbnlib
+openlibrary-client

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup, find_packages
+
+setup(name="openlibrary-bots", packages=find_packages())

--- a/tests/isbnbot/test_normalize_isbns.py
+++ b/tests/isbnbot/test_normalize_isbns.py
@@ -1,0 +1,12 @@
+from isbnlib import notisbn
+from isbnbot.normalize_isbns import NormalizeISBNJob
+
+
+def test_isbn_needs_normalization():  # TODO: Add some isbn's that need normalization
+    for isbn in "0 1234567890  Bob".split():
+        assert notisbn(isbn)
+        assert not NormalizeISBNJob.isbn_needs_normalization(isbn)
+
+    for isbn in "0123456789 0425016013 9780425016015 0441788386 9780441788385".split():
+        assert not notisbn(isbn)  # double negative
+        assert not NormalizeISBNJob.isbn_needs_normalization(isbn)

--- a/tests/isbnbot/test_normalize_isbns.py
+++ b/tests/isbnbot/test_normalize_isbns.py
@@ -10,6 +10,6 @@ def test_isbn_needs_normalization():  # TODO: Add some isbn's that need normaliz
     for isbn in "0123456789 0425016013 9780425016015 0441788386 9780441788385".split():
         assert not notisbn(isbn)  # double negative
         assert not NormalizeISBNJob.isbn_needs_normalization(isbn)
-    
+
     for isbn in ("ISBN 13: 9780425016015", "(ebook)0441788386"):
         assert not NormalizeISBNJob.isbn_needs_normalization(isbn)

--- a/tests/isbnbot/test_normalize_isbns.py
+++ b/tests/isbnbot/test_normalize_isbns.py
@@ -10,3 +10,6 @@ def test_isbn_needs_normalization():  # TODO: Add some isbn's that need normaliz
     for isbn in "0123456789 0425016013 9780425016015 0441788386 9780441788385".split():
         assert not notisbn(isbn)  # double negative
         assert not NormalizeISBNJob.isbn_needs_normalization(isbn)
+    
+    for isbn in ("ISBN 13: 9780425016015", "(ebook)0441788386"):
+        assert not NormalizeISBNJob.isbn_needs_normalization(isbn)


### PR DESCRIPTION
## Description:
In this Pull Request we have made the following changes:
* Add a pytest to get automated testing started
* Add `requirements.txt` to streamline the installation of dependencies
* Add `setup.py` as recommended in the pytest docs.
* Enable the installation of dependencies and running of pytests in our GitHub Action
```
Run pytest .
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-6.0.1, py-1.9.0, pluggy-0.13.1
rootdir: /home/runner/work/openlibrary-bots/openlibrary-bots
collected 1 item

tests/isbnbot/test_normalize_isbns.py .                                  [100%]

======================== 1 passed, 2 warnings in 0.24s =========================
```