### PR TITLE
Upgrade to Python 3.7 syntax

### DIFF
--- a/BWBImportBot/__init__.py
+++ b/BWBImportBot/__init__.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 """
     __init__.py

--- a/BWBImportBot/parse-biblio.py
+++ b/BWBImportBot/parse-biblio.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #!/usr/bin/env python3
 import sys
 import json
@@ -88,7 +87,7 @@ if __name__ == '__main__':
     seen_isbns = set()
 
     for fname in fnames:
-        with open(fname, 'r') as f:
+        with open(fname) as f:
             for line in f:
                 data = line.strip().split('|')
                 b = Biblio(data)

--- a/goodreads-scrape/script_add.py
+++ b/goodreads-scrape/script_add.py
@@ -1,4 +1,3 @@
-
 #!/usr/local/bin/python
 from olclient.openlibrary import OpenLibrary
 import olclient.common as common
@@ -16,7 +15,7 @@ author = (root[1][6][0][8][2][1]).text #author name
 image_url = (root[1][6][0][8][3]).text
 ol = OpenLibrary()
 book = common.Book(title=title, authors=[common.Author(name=author)])
-book.add_id(u'isbn_13', isbn_13)
+book.add_id('isbn_13', isbn_13)
 new_book = ol.create_book(book)
 new_book.add_bookcover(image_url)
 

--- a/google-books-bot/google_books_search.py
+++ b/google-books-bot/google_books_search.py
@@ -63,7 +63,7 @@ def _upload_ol_book(ol_book):
                          "This script doesn't yet support updating existing books -- sorry!")
 
     edition = OL.Work.create(ol_book)
-    print("Upload of {} successful!".format(edition.olid))
+    print(f"Upload of {edition.olid} successful!")
 
 
 def main():
@@ -97,7 +97,7 @@ def main():
                                                                                         number_of_considered_books))
     for i, ol_book in enumerate(ol_books):
         isbn_10 = ol_book.identifiers["isbn_10"][0]
-        print("\t{}: '{}' by {} - ISBN {}".format(i, ol_book.title, ol_book.primary_author.name, isbn_10))
+        print(f"\t{i}: '{ol_book.title}' by {ol_book.primary_author.name} - ISBN {isbn_10}")
 
     chosen_index = int(input("Which of these would you like to upload? "))
     if chosen_index > number_of_considered_books:

--- a/ia-bulkmarc-bot/bulk-import.py
+++ b/ia-bulkmarc-bot/bulk-import.py
@@ -93,7 +93,7 @@ if __name__ == '__main__':
         if limit and count >= limit:
             # Stop if a limit has been set, and we are over it.
             break
-        identifier = '{}/{}:{}:{}'.format(item, fname, offset, length)
+        identifier = f'{item}/{fname}:{offset}:{length}'
         data = {'identifier': identifier, 'bulk_marc': 'true'}
         if barcode and barcode is not True:
             # A local_id key has been passed to import a specific local_id barcode
@@ -109,7 +109,7 @@ if __name__ == '__main__':
                 error_summary = ''
             # Write error log
             error_log = log_error(r)
-            print("UNEXPECTED ERROR %s; [%s] WRITTEN TO: %s" % (r.status_code, error_summary, error_log))
+            print(f"UNEXPECTED ERROR {r.status_code}; [{error_summary}] WRITTEN TO: {error_log}")
             # Skip this record and move to the next
             # FIXME: this fails if there are 2 errors in a row :(
             if length == 5:
@@ -118,10 +118,10 @@ if __name__ == '__main__':
                 break
             offset = offset + length
             length = 5
-            print("%s:%s" % (offset, length))
+            print(f"{offset}:{length}")
             continue
         # log results to stdout
-        print('{}: {} -- {}'.format(identifier, r.status_code, result))
+        print(f'{identifier}: {r.status_code} -- {result}')
         offset = result.get('next_record_offset')
         length = result.get('next_record_length')
         count += 1

--- a/ia-sync-bot/extract-isbn.py
+++ b/ia-sync-bot/extract-isbn.py
@@ -49,5 +49,5 @@ with open(infile) as f:
                 bad_isbn.append(isbn)
 
         for bad in bad_isbn:
-            print(u"\t".join([u'BAD-ISBN:', repr(bad), olid, wolid]))
+            print("\t".join(['BAD-ISBN:', repr(bad), olid, wolid]))
 

--- a/ia-sync-bot/update-ocaid.py
+++ b/ia-sync-bot/update-ocaid.py
@@ -18,7 +18,7 @@ def sync_ol_to_ia(olid):
     else:
         content = r.json()
     if 'error' in content and 'no changes to _meta.xml' not in content['error']:  # and r.json()['error'] == 'No qualifying edition':
-        print("%s, %s: %s" % (olid, ocaid, content))
+        print(f"{olid}, {ocaid}: {content}")
     return r.status_code
 
 # start and end are False or line numbers in infile to begin and stop processing
@@ -36,7 +36,7 @@ with open(infile) as f:
        if end and count > end:
            break
        # check and add ocaid to OL edition
-       print("Adding %s to %s" % (ocaid, olid))
+       print(f"Adding {ocaid} to {olid}")
        edition = ol.get(olid)
        assert edition.title, "Missing title in %s!" % olid
 

--- a/ia-wishlist-bot/add_wishlist_works.py
+++ b/ia-wishlist-bot/add_wishlist_works.py
@@ -28,7 +28,7 @@ if not os.path.exists('data/wish_list_march_2018.ndjson'):
 		'https://archive.org/download/openlibrary-bots/wish_list_march_2018.ndjson', file_name)
 
 # Fetches all ISBNs which are currently not added to Open Library
-with open('data/ol_works.csv', 'r') as csvfile:
+with open('data/ol_works.csv') as csvfile:
     csvreader = csv.reader(csvfile)
     for row in csvreader:
 	    isbn_data.append(row[0])
@@ -47,7 +47,7 @@ start_time = time.time()
 for data in dataset:
 	# Checking if ISBN-13 for a particular data is Nonetype or not
 	if data['isbn13'] is not None:
-		y = set([data['isbn13']])
+		y = {data['isbn13']}
 		# Intersection of set of dataset ISBN-13 and wishlist ISBN-13 is taken
 		if isbn_set.intersection(y):
 			new_data.append(data)

--- a/ia-wishlist-bot/add_works_via_wishlist.py
+++ b/ia-wishlist-bot/add_works_via_wishlist.py
@@ -34,13 +34,13 @@ if not os.path.exists(FILE):
 		'https://archive.org/download/openlibrary-bots/wish_list_march_2018.ndjson', file_name)
 def row2book(new_book):
 	# Data of the book
-	title = new_book.get('title', u'')
-	author = new_book.get('author', u'')
-	date = new_book.get('date', u'')
+	title = new_book.get('title', '')
+	author = new_book.get('author', '')
+	date = new_book.get('date', '')
 
 	# Define a Book Object
 	added_book = common.Book(title=title, authors=[common.Author(
-		name=author)], publisher=u"", publish_date=date)
+		name=author)], publisher="", publish_date=date)
 
 	return added_book
 
@@ -51,16 +51,16 @@ with open(FILE) as f:
 # Iterates over the size of the data
 for new_book in data:
 
-	isbn10 = new_book.get('isbn10', u'')
-	isbn13 = new_book.get('isbn13', u'')
-	oclc = new_book.get('oclc', u'')
+	isbn10 = new_book.get('isbn10', '')
+	isbn13 = new_book.get('isbn13', '')
+	oclc = new_book.get('oclc', '')
 
 	added_book = row2book(new_book)
 
 	# Add metadata like ISBN 10 and ISBN 13
-	added_book.add_id(u'isbn_10', isbn10)
-	added_book.add_id(u'isbn_13', isbn13)
-	added_book.add_id(u'oclc', oclc)
+	added_book.add_id('isbn_10', isbn10)
+	added_book.add_id('isbn_13', isbn13)
+	added_book.add_id('oclc', oclc)
 
 	# Call create book to create the book
 	newly_added_book = ol.create_book(added_book)

--- a/ia-wishlist-bot/adding_wishlist_ol.py
+++ b/ia-wishlist-bot/adding_wishlist_ol.py
@@ -120,9 +120,9 @@ def add_book_via_olclient(book, author_list, bookcover=None):
                                publish_date=book.get("date"), language=book.get("language"))
 
         # Add metadata like ISBN 10 and ISBN 13
-        new_book.add_id(u'isbn_10', book.get("isbn10"))
-        new_book.add_id(u'isbn_13', book.get('isbn13'))
-        new_book.add_id(u'oclc', book.get('oclc'))
+        new_book.add_id('isbn_10', book.get("isbn10"))
+        new_book.add_id('isbn_13', book.get('isbn13'))
+        new_book.add_id('oclc', book.get('oclc'))
 
         print(new_book)
         try:

--- a/ia-wishlist-bot/import_wishlist_final.py
+++ b/ia-wishlist-bot/import_wishlist_final.py
@@ -34,7 +34,7 @@ count = 0
 # Array to add unduplicated books
 value = []
 
-with open(FILE, "rt") as infile:
+with open(FILE) as infile:
     reader = csv.reader(infile)
     next(reader, None)
     for row in reader:

--- a/isbnbot/normalize_isbns.py
+++ b/isbnbot/normalize_isbns.py
@@ -17,7 +17,7 @@ from os import makedirs
 ALLOWED_ISBN_CHARS = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'X', 'x', '-'}
 
 
-class NormalizeISBNJob(object):
+class NormalizeISBNJob:
     def __init__(self, ol=None, dry_run=True, limit=1):
         """Create logger and class variables"""
         if ol is None:
@@ -40,7 +40,7 @@ class NormalizeISBNJob(object):
         log_dir = 'logs/jobs/%s' % job_name
         makedirs(log_dir, exist_ok=True)
         log_file_datetime = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-        log_file = log_dir + '/%s_%s.log' % (job_name, log_file_datetime)
+        log_file = log_dir + f'/{job_name}_{log_file_datetime}.log'
         file_handler = logging.FileHandler(log_file)
         file_handler.setLevel(logging.DEBUG)
         file_handler.setFormatter(log_formatter)

--- a/modern-import-bot/import.py
+++ b/modern-import-bot/import.py
@@ -7,7 +7,7 @@ ol = OpenLibrary()
 fname = sys.argv[1]
 delay = 3
 
-with open(fname, 'r') as f:
+with open(fname) as f:
     for line in f:
         isbn = line.strip()
         time.sleep(delay)
@@ -23,5 +23,5 @@ with open(fname, 'r') as f:
                 status = 'FOUND'
         else:
             status = 'ERROR'
-        print("%s: %s%s" % (isbn, status, " AS %s" % olid if olid else ''))
+        print("{}: {}{}".format(isbn, status, " AS %s" % olid if olid else ''))
 

--- a/old-onix-bot/onix-import.py
+++ b/old-onix-bot/onix-import.py
@@ -15,7 +15,7 @@ source_path = None
 edition_prefix = None
 author_prefix = None
 
-edition_records = set([])
+edition_records = set()
 item_names = {}
 # edition_names = set ([])
 # author_names = {}
@@ -44,7 +44,7 @@ def setup():
     global source_name, source_path
     source_dir = getvar ("PHAROS_SOURCE_DIR")
     source_name = sys.argv[1]
-    source_path = "%s/%s" % (source_dir, source_name)
+    source_path = f"{source_dir}/{source_name}"
 
     global edition_prefix, author_prefix
     edition_prefix = getvar ("PHAROS_EDITION_PREFIX", False) or ""
@@ -227,5 +227,5 @@ def massage_dict (d):
 if __name__ == "__main__":
     setup()
     sys.stderr.write ("--> setup finished\n")
-    import_file (open (source_path, "r"))
+    import_file (open (source_path))
     sys.stderr.write ("--> import finished\n")

--- a/old-onix-bot/onix.py
+++ b/old-onix-bot/onix.py
@@ -11,8 +11,8 @@ from .sax_utils import *
 from .xmltramp import *
 
 repo_path = os.getenv ("PHAROS_REPO")
-codelists_path = "%s/%s" % (repo_path, "catalog/onix/ONIX_BookProduct_CodeLists.xsd")
-ref_dtd_path = "%s/%s" % (repo_path, "catalog/onix/ONIX_BookProduct_Release2.1_reference.xsd")
+codelists_path = "{}/{}".format(repo_path, "catalog/onix/ONIX_BookProduct_CodeLists.xsd")
+ref_dtd_path = "{}/{}".format(repo_path, "catalog/onix/ONIX_BookProduct_Release2.1_reference.xsd")
 
 # for testing, also set URL_CACHE_DIR; see bottom.
 
@@ -20,10 +20,10 @@ onix_codelists = None
 onix_shortnames = None
 
 def init ():
-	f = open (codelists_path, "r")
+	f = open (codelists_path)
 	onix_codelists = parse_codelists (f)
 	f.close ()
-	f = open (ref_dtd_path, "r")
+	f = open (ref_dtd_path)
 	onix_shortnames = parse_shortnames (f)
 	f.close ()
 
@@ -55,9 +55,9 @@ class OnixProduct:
 			return map (OnixProduct.reify_child, values)
 		else:
 			if len (values) == 0:
-				raise KeyError ("no value for %s (%s)" % (reference_name, name))
+				raise KeyError (f"no value for {reference_name} ({name})")
 			elif len (values) > 1:
-				raise Exception ("more than one value for %s (%s)" % (reference_name, name))
+				raise Exception (f"more than one value for {reference_name} ({name})")
 			return OnixProduct.reify_child (values[0])
 
 	def get (self, n):
@@ -145,9 +145,9 @@ def parse_codelists (input):
 						def documentation (name, attrs):
 							return TextCollector ()
 						return ListCollector ({ 'documentation': documentation })
-					return NamedCollector (attrs.getValueByQName (u'value'), { 'annotation': annotation })
+					return NamedCollector (attrs.getValueByQName ('value'), { 'annotation': annotation })
 				return DictCollector ({ 'enumeration': enumeration })
-			return NamedCollector (attrs.getValueByQName (u'name'), { 'restriction': restriction })
+			return NamedCollector (attrs.getValueByQName ('name'), { 'restriction': restriction })
 		return DictCollector ({ 'simpleType': simpleType })
 	return collector_parse (input, { 'schema': schema })
 

--- a/old-onix-bot/parse.py
+++ b/old-onix-bot/parse.py
@@ -268,8 +268,8 @@ def elt_get (e, tag, reference_name):
        else:
                return None
 
-re_by = re.compile ("^\s*by\s+", re.IGNORECASE)
-re_iname = re.compile ("^(.*),\s*(.*)$")
+re_by = re.compile (r"^\s*by\s+", re.IGNORECASE)
+re_iname = re.compile (r"^(.*),\s*(.*)$")
 
 def add_val (o, key, val):
 	if val is not None:

--- a/old-onix-bot/sax_utils.py
+++ b/old-onix-bot/sax_utils.py
@@ -116,7 +116,7 @@ class NodeCollector (Collector):
 				self.handler.push_collector (c)
 			else:
 				if self.strict:
-					raise Exception ("no handler for element '%s'; handlers: %s" % (localname, self.collector_table.keys ()))
+					raise Exception (f"no handler for element '{localname}'; handlers: {self.collector_table.keys()}")
 				else:
 					self.ignoring += 1
 	def endElementNS (self, name, qname):

--- a/old-onix-bot/urlcache.py
+++ b/old-onix-bot/urlcache.py
@@ -56,7 +56,7 @@ class URLCache:
 
 		data_file = self.dir + "/" + str (id)
 		if os.path.exists (data_file):
-			return open (data_file, "r")
+			return open (data_file)
 		else:
 			# wait for fetch to finish
 			tmp_data_file = data_file + "-fetching"
@@ -68,7 +68,7 @@ class URLCache:
 					tmp_data.close ()
 				except OSError as e:
 					pass
-				return open (data_file, "r")
+				return open (data_file)
 			except Exception as exn:
 				# in case this happens, just blow away your cache
-				raise Exception ("URLCache: sorry, corrupted state for url '%s': %s" % (url, str (exn)))
+				raise Exception ("URLCache: sorry, corrupted state for url '{}': {}".format(url, str (exn)))

--- a/old-onix-bot/xmltramp.py
+++ b/old-onix-bot/xmltramp.py
@@ -10,7 +10,7 @@ try:
 except NameError:
     unicode = str
 
-def isstr(f): return isinstance(f, (str, type(u'')))
+def isstr(f): return isinstance(f, (str, type('')))
 def islst(f): return isinstance(f, (tuple, list))
 
 empty = {'http://www.w3.org/1999/xhtml': ['img', 'br', 'hr', 'meta', 'link', 'base', 'param', 'input', 'col', 'area']}
@@ -68,7 +68,7 @@ class Element:
 
             return out
 
-        inprefixes = inprefixes or {u'http://www.w3.org/XML/1998/namespace':'xml'}
+        inprefixes = inprefixes or {'http://www.w3.org/XML/1998/namespace':'xml'}
 
         # need to call first to set inprefixes:
         attributes = arep(self._attrs, inprefixes, recursive)

--- a/onix-bot/OnixParserOld.py
+++ b/onix-bot/OnixParserOld.py
@@ -11,7 +11,7 @@ import json
 FILE = 'data/SampleONIX.xml' 
 ol = OpenLibrary()
 
-class OnixParser(object):
+class OnixParser:
     """
     ONIX Parser which parses through an ONIX File and returns valid attributes
     Attributes:

--- a/onix-bot/onixparser.py
+++ b/onix-bot/onixparser.py
@@ -1,4 +1,3 @@
-#-*- coding: utf-8 -*-
 #!/usr/bin/env python
 
 """
@@ -123,7 +122,7 @@ class TestOnixProductBot(unittest.TestCase):
         self.assertTrue(expected_status == self.opb.status)
 
 
-class OnixFeedParser(object):
+class OnixFeedParser:
 
     def __init__(self, filename, ns=""):
         parser = etree.XMLParser(ns_clean=True)
@@ -132,7 +131,7 @@ class OnixFeedParser(object):
         self.products = [OnixProductParser(product, ns) for product in self.onix.findall('Product')]
 
 
-class OnixProductParser(object):
+class OnixProductParser:
 
     def __init__(self, product, ns):
         self.ns = ns
@@ -357,7 +356,7 @@ class OnixProductParser(object):
         return json.dumps(data)
 
 
-class OnixProductBot(object):
+class OnixProductBot:
     def __init__(self, data):
         self.status = 1
         self.data = json.loads(data)

--- a/twitter-borrowbot/setup.py
+++ b/twitter-borrowbot/setup.py
@@ -9,7 +9,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 
 def requirements():
     """Returns requirements.txt as a list usable by setuptools"""  
-    reqtxt = os.path.join(here, u'requirements.txt')
+    reqtxt = os.path.join(here, 'requirements.txt')
     with open(reqtxt) as f:
         return f.read().split()
 

--- a/twitter-borrowbot/twitterbot.py
+++ b/twitter-borrowbot/twitterbot.py
@@ -18,7 +18,7 @@ FILE_NAME = 'last_seen_id.txt'
 
 
 def retrieve_last_seen_id(file_name):
-    f_read = open(file_name, 'r')
+    f_read = open(file_name)
     last_seen_id = int(f_read.read().strip())
     f_read.close()
     return last_seen_id


### PR DESCRIPTION
This PR was created by the following commands:
* `python3 -m pip install --upgrade pyupgrade`
* `pyupgrade --py37-plus **/*.py`

## Description:
In this Pull Request we have made the following changes:
* Use [pyupgrade](https://github.com/asottile/pyupgrade) to automatically upgrade syntax for Python >= 3.7.