### PR TITLE
Bulk MARC import, handling further variations on OL 500 errors

### DIFF
--- a/ia-bulkmarc-bot/bulk-import.py
+++ b/ia-bulkmarc-bot/bulk-import.py
@@ -122,8 +122,9 @@ if __name__ == '__main__':
                     sleep(50 * 60)
                     continue
             elif status == 500:
-                m = re.search(r'<h2>(.*)</h2>', r.text)
-                error_summary = m.group(1) or r.text.split()[0]
+                # In debug mode 500s produce HTML with details of the error
+                m = re.search(r'<h1>(.*)</h1>', r.text)
+                error_summary = m.group(1) or r.text
                 # Write error log
                 error_log = log_error(r)
                 print("UNEXPECTED ERROR %s; [%s] WRITTEN TO: %s" % (r.status_code, error_summary, error_log))

--- a/ia-bulkmarc-bot/bulk-import.py
+++ b/ia-bulkmarc-bot/bulk-import.py
@@ -26,6 +26,9 @@ BULK_API = '/api/import/ia'
 LOCAL_ID = re.compile(r'\/local_ids\/(\w+)')
 MARC_EXT = re.compile(r'.*\.(mrc|utf8)$')
 
+SERVER_ISSUES_WAIT = 50 * 60  # seconds to wait if server is giving unexpected 5XXs likely to be resolved in time
+SHORT_CONNECT_WAIT =  5 * 60  # seconds
+
 
 def get_marc21_files(item):
     return [f.name for f in ia.get_files(item) if MARC_EXT.match(f.name)]
@@ -119,30 +122,34 @@ if __name__ == '__main__':
                 if r.status_code == 503:
                     length = 5
                     offset = offset  # repeat current import
-                    sleep(50 * 60)
+                    sleep(SERVER_ISSUES_WAIT)
                     continue
             elif status == 500:
                 # In debug mode 500s produce HTML with details of the error
                 m = re.search(r'<h1>(.*)</h1>', r.text)
-                error_summary = m.group(1) or r.text
+                error_summary = m and m.group(1) or r.text
                 # Write error log
                 error_log = log_error(r)
                 print("UNEXPECTED ERROR %s; [%s] WRITTEN TO: %s" % (r.status_code, error_summary, error_log))
-                # Skip this record and move to the next
+
                 # FIXME: this fails if there are 2 errors in a row :(
                 if length == 5:
                     # break out of everything, 2 errors in a row
                     count = limit
                     break
-                offset = offset + length
+                if m:  # a handled, debugged, and logged error, unlikely to be resolved by retrying later:
+                    # Skip this record and move to the next
+                    offset = offset + length
+                else:
+                    sleep(SERVER_ISSUES_WAIT)
                 length = 5
                 print("%s:%s" % (offset, length))
                 continue
-            else:  # 4xx errors should have json content
+            else:  # 4xx errors should have json content, to be handled in default 200 flow
                 pass
         except ConnectionError as e:
             print("CONNECTION ERROR: %s" % e.args[0])
-            sleep(5 * 60)
+            sleep(SHORT_CONNECT_WAIT)
             continue
         # log results to stdout
         try:


### PR DESCRIPTION
Closes #<IssueNumber>

## Description:
In this Pull Request we have made the following changes:
* Not all 500 errors are exceptions caught by the debugger which will occur deterministically when provided the same input --
sometimes a 500 'Open Library is closed, try again later' message is produced, which is _not_ caused by the specific API request.

example of this logged recently:

```
UNEXPECTED ERROR 500; [<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
<html>
    <head>
        <title>Hmm...</title>
        <style type="text/css">
        body{text-align:center; background: #E2DCC5;}
        #logo{margin:45px auto 75px;}
        p{font-size:1em;line-height:1.5em;font-family:Georgia,serif;}
        </style>
    </head>
    <body>
    <div id="logo"><img src="/images/logo_OL-err.png" alt="The Open Library is closed!" width="219" height="131"/></div>
    <p><strong>Open Library is temporarily offline.</strong><br/>Please <a href="http://blog.openlibrary.org/">visit our blog</a> for updates about site status.</p>
    </body>
</html>
] WRITTEN TO: error_497.html
``` 