### PR TITLE
Recover from two 500 errors in a row

### DIFF
--- a/ia-bulkmarc-bot/bulk-import.py
+++ b/ia-bulkmarc-bot/bulk-import.py
@@ -52,7 +52,10 @@ def next_record(identifier, ol):
     current = ol.session.get(ol.base_url + '/show-records/' + identifier)
     m = re.search(r'<a href="\.\./[^/]+/[^:]+:([0-9]+):([0-9]+)".*Next</a>', current.text)
     next_offset, next_length = m.groups()
-    return next_offset, next_length
+    # Follow redirect to get actual length (next_length is always 5 to trigger the redirect)
+    r = ol.session.head(ol.base_url + '/show-records/' + re.search(r'^[^:]*', identifier).group(0) + ':%s:%s' % (next_offset, next_length))
+    next_length = re.search(r'[^:]*$', r.headers.get('Location', '5')).group(0)
+    return int(next_offset), int(next_length)
 
 
 if __name__ == '__main__':

--- a/ia-bulkmarc-bot/bulk-import.py
+++ b/ia-bulkmarc-bot/bulk-import.py
@@ -143,7 +143,7 @@ if __name__ == '__main__':
                 print("UNEXPECTED ERROR %s; [%s] WRITTEN TO: %s" % (r.status_code, error_summary, error_log))
 
                 if length == 5:
-                    # 2 500 errors in a row, skipt to next record
+                    # Two 500 errors in a row: skip to next record
                     offset, length = next_record(identifier, ol)
                     continue
                 if m:  # a handled, debugged, and logged error, unlikely to be resolved by retrying later:


### PR DESCRIPTION
by looking up correct offset of next record

Closes FIXME in previous code

When two imports fail in a row (due to data errors that will never succeed when retried), the bulk import script loses its place in the bulk MARC file as it no longer has the current offset and a correct length of the current record which are returned on a successful import.

## Description:
In this Pull Request we have made the following changes:
* Now when two errors occur in a row the code will look up the next record offset independently and resume from that point 