### PR TITLE
Adding retries + timeout backoff

### DIFF
--- a/BWBImportBot/import-ol.py
+++ b/BWBImportBot/import-ol.py
@@ -1,10 +1,20 @@
 import sys
 import json
 import requests
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
 from olclient import OpenLibrary
 
 ol = OpenLibrary()
 url = 'https://openlibrary.org/api/import'
+
+adapter = HTTPAdapter(max_retries=Retry(
+    total=5,
+    read=5,
+    connect=5,
+    backoff_factor=0.3
+))
+ol.session.mount('https://', adapter)
 
 if __name__ == '__main__':
     fname = sys.argv[1]


### PR DESCRIPTION
Fixes:
```
Traceback (most recent call last):
  File "/bwb-monthly/openlibrary-bots/BWBImportBot/import-ol.py", line 17, in <module>
    r = ol.session.post(url, data=json.dumps(data))
  File "/bwb-monthly/venv/lib/python2.7/site-packages/requests/sessions.py", line 578, in post
    return self.request('POST', url, data=data, json=json, **kwargs)
  File "/bwb-monthly/venv/lib/python2.7/site-packages/requests/sessions.py", line 530, in request
    resp = self.send(prep, **send_kwargs)
  File "/bwb-monthly/venv/lib/python2.7/site-packages/requests/sessions.py", line 643, in send
    r = adapter.send(request, **kwargs)
  File "/bwb-monthly/venv/lib/python2.7/site-packages/requests/adapters.py", line 514, in send
    raise SSLError(e, request=request)
requests.exceptions.SSLError: HTTPSConnectionPool(host='openlibrary.org', port=443): Max retries exceeded with url: /api/import (Caused by SSLError(SSLError("bad handshake: SysCallError(-1, 'Unexpected EOF')",),))
```

When too many imports running and failures occur 