### PR TITLE
Provide pip with more requirements at once

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -9,13 +9,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
+      - run: pip install --upgrade pip
       - run: pip install black codespell flake8 isort pytest
       - run: black --check . || true
       - run: codespell --ignore-words-list="didnt" --skip="*.xsd" --quiet-level=2
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
       - run: isort --profile black . || true
-      - run: pip install -r requirements.txt
-      - run: pip install -r twitter-borrowbot/requirements.txt
+      - run: pip install -r requirements.txt -r twitter-borrowbot/requirements.txt
       - run: pip list --outdated
       - run: pip install -e .  # https://docs.pytest.org/en/stable/goodpractices.html
       - run: pytest .


### PR DESCRIPTION
This allows the new pip dependency resolver to be more effective...
https://github.com/internetarchive/openlibrary-bots/runs/1576193848#step:10:53

> ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
> openlibrary-client 0.0.20 requires requests[security]==2.25.0, but you have requests 2.24.0 which is incompatible.
> Successfully installed PySocks-1.7.1 certifi-2020.6.20 isbnlib-3.10.3 oauthlib-3.1.0 python-dotenv-0.14.0 requests-2.24.0 requests-oauthlib-1.3.0 tweepy-3.9.0 urllib3-1.25.10
> WARNING: You are using pip version 20.3.1; however, version 20.3.3 is available.


Closes #<IssueNumber>

## Description:
In this Pull Request we have made the following changes:
* 