### PR TITLE
More tolerant ISBN normalizer (rebased on AbstractBotJob)

### DIFF
--- a/isbnbot/normalize_isbns.py
+++ b/isbnbot/normalize_isbns.py
@@ -2,49 +2,16 @@
 normalize ISBNs
 NOTE: This script assumes the Open Library Dump passed only contains editions with an isbn_10 or isbn_13
 """
-import argparse
-import datetime
 import isbnlib
 import gzip
 import json
-import logging
-import sys
 
-from olclient.openlibrary import OpenLibrary
-from os import makedirs
-
+import olclient
 
 ALLOWED_ISBN_CHARS = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'X', 'x', '-'}
 
 
-class NormalizeISBNJob(object):
-    def __init__(self, ol=None, dry_run=True, limit=1):
-        """Create logger and class variables"""
-        if ol is None:
-            self.ol = OpenLibrary()
-        else:
-            self.ol = ol
-
-        self.changed = 0
-        self.dry_run = dry_run
-        self.limit = limit
-
-        job_name = sys.argv[0].replace('.py', '')
-        self.logger = logging.getLogger("jobs.%s" % job_name)
-        self.logger.setLevel(logging.DEBUG)
-        log_formatter = logging.Formatter('%(name)s;%(levelname)-8s;%(asctime)s %(message)s')
-        self.console_handler = logging.StreamHandler()
-        self.console_handler.setLevel(logging.WARN)
-        self.console_handler.setFormatter(log_formatter)
-        self.logger.addHandler(self.console_handler)
-        log_dir = 'logs/jobs/%s' % job_name
-        makedirs(log_dir, exist_ok=True)
-        log_file_datetime = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-        log_file = log_dir + '/%s_%s.log' % (job_name, log_file_datetime)
-        file_handler = logging.FileHandler(log_file)
-        file_handler.setLevel(logging.DEBUG)
-        file_handler.setFormatter(log_formatter)
-        self.logger.addHandler(file_handler)
+class NormalizeISBNJob(olclient.AbstractBotJob):
 
     @staticmethod
     def isbn_needs_normalization(isbn: str) -> bool:
@@ -60,7 +27,7 @@ class NormalizeISBNJob(object):
             normalized_isbn = isbnlib.get_canonical_isbn(isbn)  # get_canonical_isbn returns None if ISBN is invalid
             return normalized_isbn and normalized_isbn != isbn
 
-    def run(self, dump_filepath: str) -> None:
+    def run(self) -> None:
         """
         Performs ISBN normalization (removes hyphens and capitalizes letters)
 
@@ -75,18 +42,20 @@ class NormalizeISBNJob(object):
                   'last_modified': 3,
                   'JSON': 4}
         comment = 'normalize ISBN'
-        with gzip.open(dump_filepath, 'rb') as fin:
+        with gzip.open(self.args.file, 'rb') as fin:
             for row_num, row in enumerate(fin):
                 row = row.decode().split('\t')
                 _json = json.loads(row[header['JSON']])
-                if _json['type']['key'] != '/type/edition': continue
+                if _json['type']['key'] != '/type/edition':
+                    continue
 
                 isbns_by_type = dict()
                 if 'isbn_10' in _json:
                     isbns_by_type['isbn_10'] = _json.get('isbn_10', None)
                 if 'isbn_13' in _json:
                     isbns_by_type['isbn_13'] = _json.get('isbn_13', None)
-                if not isbns_by_type: continue
+                if not isbns_by_type:
+                    continue
 
                 needs_normalization = any([
                     self.isbn_needs_normalization(isbn)
@@ -97,9 +66,11 @@ class NormalizeISBNJob(object):
 
                 olid = _json['key'].split('/')[-1]
                 edition = self.ol.Edition.get(olid)
-                if edition.type['key'] != '/type/edition': continue
+                if edition.type['key'] != '/type/edition':
+                    continue
 
-                for isbn_type, isbns in isbns_by_type.items():  # if an ISBN is in the wrong field this script will not move it to the appropriate one
+                for isbn_type, isbns in isbns_by_type.items():
+                    # if an ISBN is in the wrong field this script will not move it to the appropriate one
                     normalized_isbns = list()
                     isbns = getattr(edition, isbn_type, [])
                     for isbn in isbns:
@@ -114,54 +85,21 @@ class NormalizeISBNJob(object):
                         self.logger.info('\t'.join([olid, str(isbns), str(normalized_isbns)]))
                         self.save(lambda: edition.save(comment=comment))
 
-    def save(self, save_fn):
-        """Modify default save behavior based on 'limit' and 'dry_run' parameters"""
-        if not self.dry_run:
-            save_fn()
-        else:
-            self.logger.info('Modification not made because dry_run is True')
-        self.changed += 1
-        if self.limit and self.changed >= self.limit:
-            self.logger.info('Modification limit reached. Exiting script.')
-            sys.exit()
 
-
-def str2bool(value):
-    if isinstance(value, bool):
-        return value
-    if value.lower() in ('yes', 'true', 't', 'y', '1'):
-        return True
-    elif value.lower() in ('no', 'false', 'f', 'n', '0'):
-        return False
-    else:
-        raise argparse.ArgumentTypeError('Boolean value expected.')
-
-
-def dedupe(input: list) -> list:
+def dedupe(input_list: list) -> list:
     """Remove duplicate elements in a list and return the new list"""
     output = list()
-    for i in input:
+    for i in input_list:
         if i not in output:
             output.append(i)
     return output
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument('--dump_path', type=str, default=None,
-                        help='Path to *.txt.gz containing OpenLibrary editions data')
-    parser.add_argument('--limit', type=int, default=1,
-                        help='Limit number of edits performed on OpenLibrary data. Set to zero to allow unlimited edits')
-    parser.add_argument('--dry-run', type=str2bool, default=True,
-                        help="Don't actually perform edits on Open Library")
-    _args = parser.parse_args()
-
-    _ol = OpenLibrary()
-    bot = NormalizeISBNJob(ol=_ol, dry_run=_args.dry_run, limit=_args.limit)
-    bot.console_handler.setLevel(logging.INFO)
+    job = NormalizeISBNJob()
 
     try:
-        bot.run(_args.dump_path)
+        job.run()
     except Exception as e:
-        bot.logger.exception("")
+        job.logger.exception(e)
         raise e

--- a/isbnbot/test_normalize_isbns.py
+++ b/isbnbot/test_normalize_isbns.py
@@ -1,0 +1,110 @@
+import unittest
+
+import normalize_isbns
+
+class NormalizeISBNJobTestCase(unittest.TestCase):
+
+    single = {
+        '0-19-852663-6': ['0198526636'],
+        '0-9752298-0-X': ['097522980X'],
+        '3-444-101-11-2': ['3444101112'],
+        '978-1619636071': ['9781619636071'],
+        '978-3-16-148410-0': ['9783161484100'],
+        'ISBN 979-10-90636-07-1': ['9791090636071'],
+        'ISBN: 2-7535-0291-9': ['2753502919'],
+        '0 - 934314 - 08 - x': ['093431408X'],
+        'I.S.B.N: 978-9947-834-43-5': ['9789947834435'],
+        'ISBN: 978-0-620-45358-5': ['9780620453585'],
+        '9706544526 (Colección)': ['9706544526'],
+        '9071066045 (Stichting Oud-Muiderberg)': ['9071066045'],
+        'ISBN9984-725-71-5': ['9984725715'],
+        'ISBN   88-8191-235X': ['888191235X'],
+        '978 971 92645 3 8': ['9789719264538'],
+        '2.902.639.57.0': ['2902639570'],
+        'ISBN-978-958-660-120-7': ['9789586601207'],
+    }
+    double = {
+        '0-9752298-0-X 0-19-852663-6': ['097522980X','0198526636'],
+        '9789585596689-9789585596672': ['9789585596689', '9789585596672'],
+        '9789585596689 - 0-9752298-0-X': ['9789585596689', '097522980X'],
+        '28458625552876144972': ['2845862555', '2876144972'],
+        '978-84-96785-10-6. 978-84-96785-44-1': ['9788496785106', '9788496785441'],
+        '978-608-4501-13-8; 978-608-65045-4-0': ['9786084501138', '9786086504540'],
+        '0-380-75964-0 / 978-0-380-75964-4 (USA edition)': ['0380759640', '9780380759644'],
+        '978-0-380-75964-4 (USA edition) /0-380-75964-0 ': ['9780380759644','0380759640'],
+        'ISBN 2-7535-0291-9ISBN 978-2-296-09310-2  ': ['2753502919', '9782296093102'],
+    }
+    multi = { # we 
+        '978-84-96785-10-6. 978-84-96785-44-19789585596689': ['9788496785106','9788496785441','9789585596689'],
+        '0-9752298-0-X 0-19-852663-6 / 28458625552876144972': ['097522980X','0198526636', '2845862555', '2876144972'],
+        '978-84-96785-10-6. 978-84-96785-44-1978-608-4501-13-8; 978-608-65045-4-0': ['9788496785106', '9788496785441','9786084501138','9786086504540'],
+        '978-2-296-09310-2  978-84-96785-10-6. 978-84-96785-44-19789585596689': ['9782296093102', '9788496785106','9788496785441','9789585596689'],
+    }
+    tricky = {
+        # same number twice, note dedupe is done after
+        '97815420429639781542042963': ['9781542042963', '9781542042963'],
+        # tab character
+        '\t978-83-8169-344-8': ['9788381693448'],
+        # unicode
+        '978\xad-85-\xad913035-\xad0-\xad2': ['9788591303502'],
+        '\u202c978-3-86850-235-0': ['9783868502350'],
+        # isbn13 with 13 somewhere in the string
+        '1567445144 (ISBN13: 9781567445145)': ['9781567445145'], # note we ignore the isbn10
+        '13-978-951-558-248-5': ['9789515582485'],
+        '13:978-1478322221': ['9781478322221'],
+        '(ISBN13: 9781492993780': ['9781492993780'],
+        # lots of extra numbers
+        'ISBN # 978-1-4243-0080-8 Registration Number TXu -1 - 333 – 097 Effective Date of Registration 11 Dec 2006': ['9781424300808'],
+    }
+    invalid = [
+        '11111111112222222222222'
+        '9881567445145',
+        '0-19-852X663-6',
+    ]
+    ignored = [
+        '978',
+        '-3-',
+        '-16-',
+        '-14810-0',
+        # TODO match these common non-isbn entries and blank them
+        # check short isbns, blank common ones, levenshtien against existing
+        # fill 10 from 13 and vice versa
+        # list 10 and 13 char ISBNs that isbnlib doesn't like the look of
+        '$10.00',
+        'N/A',
+        'bought 2001-12-25',
+        '',
+    ]
+
+    def test_single_inputs(self):
+        for input, expectedoutput in iter(self.single.items()):
+            with self.subTest('single input:' + input):
+                self.assertEqual(normalize_isbns.parse_isbns(input), expectedoutput)
+
+    def test_double_inputs(self):
+        for input, expectedoutput in iter(self.double.items()):
+            with self.subTest('double input:' + input):
+                self.assertEqual(normalize_isbns.parse_isbns(input), expectedoutput)
+
+    def test_multi_inputs(self):
+        for input, expectedoutput in iter(self.multi.items()):
+            with self.subTest('multi input:' + input):
+                self.assertEqual(normalize_isbns.parse_isbns(input), expectedoutput)
+
+    def test_tricky_inputs(self):
+        for input, expectedoutput in iter(self.tricky.items()):
+            with self.subTest('tricky input:' + input):
+                self.assertEqual(normalize_isbns.parse_isbns(input), expectedoutput)
+
+    def test_invalid_inputs(self):
+        for input in self.invalid:
+            with self.subTest('Invalid input:' + input):
+                self.assertFalse(normalize_isbns.parse_isbns(input))
+
+    def test_ignored_inputs(self):
+        for input in self.ignored:
+            with self.subTest('Should ignore:' + input):
+                self.assertFalse(normalize_isbns.parse_isbns(input))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This changes the ISBN normalizer so that it's a little bit more accepting of what it checks, and a little more strict on what it then decides to change.

In the first step, it just looks for any string longer than 13 chars.

In the second step, it only changes things that exactly match as an isbn (or two) once non-isbn characters are removed.

This will now cope with spaces, dots, commas and other random punctuation or text that would previously have prevented the bot checking them, but will leave alone isbns with extra characters that make it ambigous e.g. rather than try to regex the isbn out of "ISBN: 978 - 0-545.01022.1 (1st paperback ed.)" it'll just leave it as it is because the 1 digit in 1st gets joined to the other digts and it'll no longer look like a valid ISBN. This seems a valid trade-off to catch more oddly formatted isbns while not chopping longer isbnlike strings if the prefix happens to match a valid isbn10.

When creating the PR I noticed another open PR that moves the bot to use the Abstract Bot class, which seems like a good improvement, so rebased this onto that. https://github.com/internetarchive/openlibrary-bots/pull/117

I noticed some existing tests in tests/isbnbot/test_normalize_isbns.py but couldn't run them even on the old branch, I'd be happy to add new tests for the current bot if there's a standard approach to doing so.
