### PR TITLE
pytest --ignore=twitter-borrowbot/test_borrowbot.py

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -18,5 +18,5 @@ jobs:
       - run: pip install -r requirements.txt -r twitter-borrowbot/requirements.txt
       - run: pip list --outdated
       - run: pip install -e .  # https://docs.pytest.org/en/stable/goodpractices.html
-      - run: pytest .
+      - run: pytest --ignore=twitter-borrowbot/test_borrowbot.py
       # - run: pytest --doctest-modules . || true


### PR DESCRIPTION
Is there a better way to fix our [failing GitHub Actions](https://github.com/internetarchive/openlibrary-bots/pulls) rather than ignoring these tests?

% `pytest`
```
============================= test session starts ==============================
platform linux -- Python 3.10.0, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /home/runner/work/openlibrary-bots/openlibrary-bots
collected 1 item / 1 error

==================================== ERRORS ====================================
_____________ ERROR collecting twitter-borrowbot/test_borrowbot.py _____________
twitter-borrowbot/test_borrowbot.py:4: in <module>
    from twitterbot import Tweet
twitter-borrowbot/twitterbot.py:24: in <module>
    raise twitterbotErrors.TweepyAuthenticationError(error="Missing .env file or missing necessary keys for authentication")
E   twitterbotErrors.TweepyAuthenticationError: TweepyAuthenticationError: Failed to Authenticate with Twitter through Tweepy >> Missing .env file or missing necessary keys for authentication
=========================== short test summary info ============================
ERROR twitter-borrowbot/test_borrowbot.py - twitterbotErrors.TweepyAuthentica...
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
=============================== 1 error in 0.50s ===============================
```

@robertIanClarkson 