### PR TITLE
GitHub Actions: Replace flake8 with ruff

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -25,6 +25,6 @@ jobs:
       - run: pip install -r requirements.txt -r BWBCoverBot/requirements.txt -r twitter-borrowbot/requirements.txt
       - run: pip install --editable .  # https://docs.pytest.org/en/stable/goodpractices.html
       - run: pip list --outdated
-      - run: mypy --exclude "old-onix-bot" --exclude "twitter-borrowbot" --install-types . || true
+      - run: mypy --exclude "old-onix-bot" --exclude "twitter-borrowbot" --install-types --non-interactive . || true
       - run: pytest
       # - run: pytest --doctest-modules . || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -4,21 +4,27 @@ on:
   push:
     branches: [master]
 jobs:
-  lint_python:
+  codespell_ruff_and_black:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: pip install --user black "codespell[toml]" ruff
+    - run: codespell
+    - run: ruff --format=github .
+    - run: black --check .
+
+  mypy_and_pytest:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - run: pip install --upgrade pip setuptools
-      - run: pip install black codespell flake8 isort pytest tomli
-      - run: black --check .
-      - run: codespell  # See pyproject.toml for config
-      - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-      - run: isort --profile black .
+      - run: pip install --upgrade pip setuptools wheel
+      - run: pip install mypy pytest
       - run: pip install -r requirements.txt -r BWBCoverBot/requirements.txt -r twitter-borrowbot/requirements.txt
-      - run: pip list --outdated
       - run: pip install --editable .  # https://docs.pytest.org/en/stable/goodpractices.html
+      - run: pip list --outdated
+      - run: mypy --exclude "old-onix-bot" --exclude "twitter-borrowbot" --install-types . || true
       - run: pytest
       # - run: pytest --doctest-modules . || true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,13 +23,19 @@ repos:
         args:
           - --markdown-linebreak-ext=md
 
-  # - repo: https://github.com/MarcoGorelli/auto-walrus
-  #  rev: v0.2.2
-  #  hooks:
-  #    - id: auto-walrus
+  - repo: https://github.com/MarcoGorelli/auto-walrus
+    rev: v0.2.2
+    hooks:
+      - id: auto-walrus
+
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.259
+    hooks:
+      - id: ruff  # See pyproject.toml for args
+        # args: [--fix, --exit-non-zero-on-fix]
 
   - repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 23.3.0
     hooks:
       - id: black  # See pyproject.toml for args
 
@@ -40,23 +46,8 @@ repos:
         additional_dependencies:
           - tomli
 
-  # - repo: https://github.com/pre-commit/mirrors-mypy
-  #  rev: 'v1.0.0'
-  #  hooks:
-  #    - id: mypy  # See pyproject.toml for args
-  #      additional_dependencies:
-  #        - types-all
-
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
-    hooks:
-      - id: pyupgrade
-        args:
-          - --py38-plus
-          - --keep-runtime-typing
-
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: "0.9.2"
+    rev: 0.9.2
     hooks:
       - id: pyproject-fmt
 
@@ -64,8 +55,3 @@ repos:
     rev: v0.12.2
     hooks:
       - id: validate-pyproject
-
-  - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
-    hooks:
-      - id: flake8  # See the file .flake8 for args

--- a/CommaTheBot/CommaTheBot.py
+++ b/CommaTheBot/CommaTheBot.py
@@ -1,10 +1,11 @@
 # example invocation
 # python CommaTheBot.py --file filtered_ol_dump_2022-06-06.txt.gz --limit 1
 
-from olclient.bots import AbstractBotJob
 import copy
 import gzip
 import re
+
+from olclient.bots import AbstractBotJob
 
 
 class CommaTheBotJob(AbstractBotJob):
@@ -53,7 +54,7 @@ class CommaTheBotJob(AbstractBotJob):
                     self.ol.Edition.get(olid) if isEdition else self.ol.Work.get(olid)
                 )
 
-                if not book.type["key"] in ("/type/edition", "/type/work"):
+                if book.type["key"] not in ("/type/edition", "/type/work"):
                     continue  # skip deleted books
                 if not self.needs_fixing(book.title):
                     continue

--- a/CommaTheBot/test_CommaTheBot.py
+++ b/CommaTheBot/test_CommaTheBot.py
@@ -1,4 +1,5 @@
 import unittest
+
 from CommaTheBot import CommaTheBotJob
 
 commaTheBot = CommaTheBotJob()

--- a/ia-wishlist-bot/adding_wishlist_ol.py
+++ b/ia-wishlist-bot/adding_wishlist_ol.py
@@ -134,8 +134,7 @@ def get_author_object(author_name, author_birth_date=None, author_death_date=Non
             break
         author_name = author_name_new
 
-    author_olid = ol.Author.get_olid_by_name(author_name)
-    if author_olid:
+    if author_olid := ol.Author.get_olid_by_name(author_name):
         return ol.get(author_olid)
     else:
         return common.Author(name=author_name)

--- a/ia-wishlist-bot/adding_wishlist_ol.py
+++ b/ia-wishlist-bot/adding_wishlist_ol.py
@@ -91,7 +91,7 @@ def process_csv(filename):
     with open(filename) as infile:
         reader = csv.reader(infile)
 
-        book_data = [row for row in reader]
+        book_data = list(reader)
 
         return book_data
 

--- a/isbnbot/normalize_isbns.py
+++ b/isbnbot/normalize_isbns.py
@@ -2,10 +2,10 @@
 normalize ISBNs
 NOTE: This script assumes the Open Library Dump passed only contains editions with an isbn_10 or isbn_13
 """
-import isbnlib
 import gzip
 import json
 
+import isbnlib
 import olclient
 
 
@@ -33,7 +33,7 @@ class NormalizeISBNJob(olclient.AbstractBotJob):
                 if _json["type"]["key"] != "/type/edition":
                     continue
 
-                isbns_by_type = dict()
+                isbns_by_type = {}
                 if "isbn_10" in _json:
                     isbns_by_type["isbn_10"] = _json.get("isbn_10", None)
                 if "isbn_13" in _json:
@@ -43,11 +43,9 @@ class NormalizeISBNJob(olclient.AbstractBotJob):
                     continue
 
                 needs_normalization = any(
-                    [
-                        self.isbn_needs_normalization(isbn)
-                        for isbns in isbns_by_type.values()
-                        for isbn in isbns
-                    ]
+                    self.isbn_needs_normalization(isbn)
+                    for isbns in isbns_by_type.values()
+                    for isbn in isbns
                 )
                 if not needs_normalization:
                     continue
@@ -59,7 +57,7 @@ class NormalizeISBNJob(olclient.AbstractBotJob):
 
                 for isbn_type, isbns in isbns_by_type.items():
                     # if an ISBN is in the wrong field this script will not move it to the appropriate one
-                    normalized_isbns = list()
+                    normalized_isbns = []
                     isbns = getattr(edition, isbn_type, [])
                     for isbn in isbns:
                         parsed = parse_isbns(isbn)
@@ -79,7 +77,7 @@ class NormalizeISBNJob(olclient.AbstractBotJob):
 
 def dedupe(input_list: list) -> list:
     """Remove duplicate elements in a list and return the new list"""
-    output = list()
+    output = []
     for i in input_list:
         if i not in output:
             output.append(i)

--- a/old-onix-bot/onix-import.py
+++ b/old-onix-bot/onix-import.py
@@ -32,7 +32,12 @@ def setup():
     dbname = getvar("PHAROS_DBNAME")
     dbuser = getvar("PHAROS_DBUSER")
     dbpass = getvar("PHAROS_DBPASS")
-    web.config.db_parameters = dict(dbn="postgres", db=dbname, user=dbuser, pw=dbpass)
+    web.config.db_parameters = {
+        "dbn": "postgres",
+        "db": dbname,
+        "user": dbuser,
+        "pw": dbpass,
+    }
     web.db._hasPooling = False
     web.config.db_printing = False
     web.load()

--- a/old-onix-bot/onix-import.py
+++ b/old-onix-bot/onix-import.py
@@ -42,8 +42,7 @@ def setup():
     web.config.db_printing = False
     web.load()
     tdb.setup()
-    logfile = getvar("PHAROS_LOGFILE", False)
-    if logfile:
+    if logfile := getvar("PHAROS_LOGFILE", False):
         tdb.logger.set_logfile(open(logfile, "a"))
         sys.stderr.write(f"logging to {logfile}\n")
 
@@ -105,8 +104,7 @@ def import_author(x):
     a = None
 
     global item_names
-    aid = item_names.get(name, None)
-    if aid:
+    if aid := item_names.get(name, None):
         a = LazyThing(aid)
         # warn ("---------------------------> already author %s" % name)
     else:
@@ -188,23 +186,19 @@ def edition_name_choices(x):
     name = name[0:30]
     yield name
 
-    ed_number = x.get("edition_number")
-    if ed_number:
+    if ed_number := x.get("edition_number"):
         name = tsep.join([name, name_string(ed_number)])
         yield name
 
-    ed_type = x.get("edition_type")
-    if ed_type:
+    if ed_type := x.get("edition_type"):
         name = tsep.join([name, name_string(ed_type)])
         yield name
 
-    ed = x.get("edition")
-    if ed:
+    if ed := x.get("edition"):
         name = tsep.join([name, name_string(ed)])
         yield name
 
-    format = x.get("physical_format")
-    if format:
+    if format := x.get("physical_format"):
         name = tsep.join([name, name_string(format)])
         yield name
 

--- a/old-onix-bot/onix.py
+++ b/old-onix-bot/onix.py
@@ -195,8 +195,7 @@ def produce_items(input, produce):
     parser = xml.sax.make_parser()
     parser.setFeature(xml.sax.handler.feature_namespaces, 1)
     parser.setContentHandler(OnixHandler(parser, process_item))
-    url_cache_dir = os.getenv("URL_CACHE_DIR")
-    if url_cache_dir:
+    if url_cache_dir := os.getenv("URL_CACHE_DIR"):
         sys.stderr.write(f"using url cache in {url_cache_dir}\n")
         parser.setEntityResolver(CachingEntityResolver(parser, url_cache_dir))
     else:

--- a/old-onix-bot/xmltramp.py
+++ b/old-onix-bot/xmltramp.py
@@ -47,12 +47,12 @@ def quote(x, elt=True):
 
 class Element:
     def __init__(self, name, attrs=None, children=None, prefixes=None, line=None):
-        if islst(name) and name[0] == None:
+        if islst(name) and name[0] is None:
             name = name[1]
         if attrs:
             na = {}
             for k in attrs.keys():
-                if islst(k) and k[0] == None:
+                if islst(k) and k[0] is None:
                     na[k[1]] = attrs[k]
                 else:
                     na[k] = attrs[k]
@@ -86,7 +86,7 @@ class Element:
             out = ""
 
             for p in self._prefixes.keys():
-                if not p in inprefixes.keys():
+                if p not in inprefixes.keys():
                     if addns:
                         out += " xmlns"
                     if addns and self._prefixes[p]:
@@ -391,7 +391,7 @@ def unittest():
     except AttributeError:
         pass
 
-    assert hasattr(d, "bar") == True
+    assert hasattr(d, "bar") is True
 
     assert d("foo") == "bar"
     d(silly="yes")

--- a/onix-bot/onixparser.py
+++ b/onix-bot/onixparser.py
@@ -329,8 +329,7 @@ class OnixProductParser:
             >>> p = op.products[0]
             >>> p.publication_country
         """
-        publication_country = self.product.xpath("//CountryOfPublication")
-        if publication_country:
+        if publication_country := self.product.xpath("//CountryOfPublication"):
             return publication_country[0].text
         else:
             return ""
@@ -351,8 +350,7 @@ class OnixProductParser:
             >>> p = op.products[0]
             >>> p.publication_city
         """
-        publication_city = self.product.xpath("//CityOfPublication")
-        if publication_city:
+        if publication_city := self.product.xpath("//CityOfPublication"):
             return publication_city[0].text
         else:
             return ""

--- a/promise-bot/fix_promise_items.py
+++ b/promise-bot/fix_promise_items.py
@@ -4,11 +4,10 @@ Fix promise items
 import argparse
 import errno
 import sys
-
 from configparser import ConfigParser
 from pathlib import Path
 
-from olclient.openlibrary import OpenLibrary, Config
+from olclient.openlibrary import Config, OpenLibrary
 
 DEFAULT_BATCH_SIZE = 1000
 DEFAULT_START_LINE = 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,50 @@
 [tool.codespell]
 ignore-words-list = 'didnt'
-skip = '*.xsd'
+skip = './.*,*.xsd'
+
+[tool.ruff]
+select = [
+  "C4",      # flake8-comprehensions
+  "C90",     # mccabe
+  "E",       # pycodestyle
+  "F",       # Pyflakes
+  "I",       # isort
+  "ICN",     # flake8-import-conventions
+  "PGH",     # pygrep-hooks
+  "PIE",     # flake8-pie
+  "PLC",     # Pylint conventions
+  "PLE",     # Pylint errors
+  "PLR091",  # Pylint refactor just for max-args, max-branches, etc.
+  "PYI",     # flake8-pyi
+  "RSE",     # flake8-raise
+  "RUF",     # Ruff-specific rules
+  "T10",     # flake8-debugger
+  "TCH",     # flake8-type-checking
+  "TID",     # flake8-tidy-imports
+  "UP",      # pyupgrade
+  "W",       # pycodestyle
+  "YTT",     # flake8-2020
+]
+ignore = [
+  "E402",
+  "E722",
+  "F401",
+  "F403",
+  "F405",
+  "F841",
+  "PLC1901",
+  "RUF001",
+]
+line-length = 616
+target-version = "py37"
+
+[tool.ruff.mccabe]
+max-complexity = 21
+
+[tool.ruff.pylint]
+max-args = 8
+max-branches = 18
+max-statements = 73
+
+[tool.ruff.per-file-ignores]
+"test/*" = ["S101"]

--- a/tests/coverbot/test_cover_updater.py
+++ b/tests/coverbot/test_cover_updater.py
@@ -1,5 +1,6 @@
 import unittest
 from random import randint
+
 from coverbot.cover_updater import AddInternetArchiveCoverJob as job
 
 

--- a/twitter-borrowbot/twitterbot.py
+++ b/twitter-borrowbot/twitterbot.py
@@ -238,7 +238,7 @@ def reply_to_tweets():
 
             # Reply to me
             if not isbns and parent_mention.user.id == API.me().id:
-                logging.info(f"IS REPLY TO ME")
+                logging.info("IS REPLY TO ME")
                 continue
         if isbns:
             for isbn in isbns:


### PR DESCRIPTION
[Ruff](https://beta.ruff.rs/) supports [over 500 lint rules](https://beta.ruff.rs/docs/rules) and can be used to replace [Flake8](https://pypi.org/project/flake8/) (plus dozens of plugins), [isort](https://pypi.org/project/isort/), [pydocstyle](https://pypi.org/project/pydocstyle/), [yesqa](https://github.com/asottile/yesqa), [eradicate](https://pypi.org/project/eradicate/), [pyupgrade](https://pypi.org/project/pyupgrade/), and [autoflake](https://pypi.org/project/autoflake/), all while executing (in Rust) tens or hundreds of times faster than any individual tool.

Running `ruff --format=github .` in GitHub Actions will rapidly provide intuitive GitHub Annotations to contributors.

![image](https://user-images.githubusercontent.com/3709715/223758136-afc386d2-70aa-4eff-953a-2c2d82ceea23.png)

Includes changes made by:
% ruff --select=C408,C416,E711,E712,E713,F541,I001,PIE802 --fix .