### PR TITLE
Updates elementpath from 4.2.1 to 4.3.0

### DIFF
--- a/goodreads-scrape/requirements.txt
+++ b/goodreads-scrape/requirements.txt
@@ -1,5 +1,5 @@
 requests==2.31.0
-elementpath==4.2.1
+elementpath==4.3.0
 openlibrary-client==0.0.30
 openlibrary==0.0.1
 openlibrary-api==0.1.0


### PR DESCRIPTION
    v4.3.0 (2024-02-17)

        Change the purpose of the evaluation with a dynamic schema context, that is now used only for labeling tokens with XSD types
        The static evaluation is now performed also when a schema is provided to the parser
        First tests with Python 3.13 pre-releases by adding a tox.ini testenv
</details>
