### PR TITLE
Add wikidata_backfill bot to AgenticCommonsBot for evidence-driven remote_ids.wikidata additions

### DIFF
--- a/AgenticCommonsBot/wikidata_backfill/README.md
+++ b/AgenticCommonsBot/wikidata_backfill/README.md
@@ -1,0 +1,104 @@
+# AgenticCommonsBot — wikidata_backfill
+
+Evidence-driven Wikidata Q-id backfill for OpenLibrary author `remote_ids.wikidata`.
+
+Sibling of `AgenticCommonsBot/` (the alternate_names bot). Same OL bot account
+(`agenticcommonsbot`), different field scope.
+
+Around 67% of OL author records have no `remote_ids.wikidata`. Filling this
+identity anchor also unblocks author-record deduplication downstream — the
+Q-id is the strongest cross-source join key for deciding whether two OL
+author records are the same person (context in the linked issue).
+
+For OL authors whose `remote_ids.wikidata` is currently empty, this bot reads
+a pre-verified proposal, re-fetches the Wikidata entity to confirm the
+evidence still holds, and PUTs the single new value in one edit.
+
+## What this bot does
+
+Two modes, both pure stdlib:
+
+### `discover` — find candidates
+
+Stream the monthly author dump (`ol_dump_authors_latest.txt.gz`), filter to
+authors that:
+- have `remote_ids.wikidata` **empty**
+- have `birth_date` present (name-only matching is too weak for common names)
+- are not redirects / deletes
+
+Emit OL author keys to stdout, one per line.
+
+### `sync` — actually edit one author
+
+For one OL author key + one candidate Q-id (from a proposal JSON):
+1. POST `/account/login` with S3 keys → write-capable session
+2. GET `/authors/<key>.json` → current `remote_ids`, confirm `wikidata` still empty
+3. GET Wikidata `Special:EntityData/<Q-id>.json` → confirm entity exists, is a Q5 human, and evidence claims (P648 for Source A; P569 / P570 / P106 for Source B) are still present
+4. If OL already has `remote_ids.wikidata` populated → skip (conflict, never overwrite)
+5. If Wikidata evidence no longer holds → skip (revalidation failure)
+6. Otherwise PUT updated record with `remote_ids.wikidata = "Q..."` appended (all other identifiers untouched)
+7. Verify via re-fetch GET
+
+## What this bot does NOT do
+
+- Does not decide the identity match at PUT time. Match is decided upstream — Source A: Wikidata's own P648 self-declaration; Source B: research worker + QA gate on structured multi-field evidence.
+- Does not crawl OL. Candidate discovery uses the monthly bulk dump. Per-author work uses one GET (OL) + one GET (Wikidata) + one PUT (OL) + one verify GET (OL).
+- Does not edit works, editions, subjects, or any field other than `remote_ids.wikidata`.
+- Does not remove or overwrite any existing entry in the `remote_ids` map — it only adds the `wikidata` key when it was previously absent.
+- Does not handle author record duplicates (a separate concern; this backfill is the anchor that makes dedup tractable).
+- Does not invent Q-ids. The QID must resolve to a real Wikidata entity at PUT time; if the entity is missing or has been merged/redirected, the bot skips.
+
+## Why this design
+
+`remote_ids.wikidata` is an identity anchor — writing the wrong Q-id fuses two
+authors together, which is worse than leaving the field empty. So the review
+bar is deliberately higher than for `alternate_names`:
+
+| Concern | Resolution |
+|---|---|
+| OL is hammered by crawler traffic | Use monthly bulk dump for candidate discovery, not OL search / list APIs |
+| Weak identity matching (name alone) | `birth_date` is required on OL side; Source B requires ≥ 2 structured Wikidata fields to match, with evidence citing specific P-ids |
+| LLM hallucination of Q-ids | Every QID is re-fetched from Wikidata at PUT time; entity must exist and be Q5 (human); evidence claims must still be present |
+| Overwriting a differently-linked author | Skip any author whose `remote_ids.wikidata` is already populated, even if the on-file Q-id disagrees with the proposal — those go to a human conflict-review queue, never to the bot |
+
+## Frequency
+
+Per-day cap of 8 edits initially. Each edit makes 1 GET (Wikidata) + 1 GET
+(OL) + 1 PUT (OL) + 1 verify GET (OL) = 4 HTTP calls. Monthly dump fetch is
+one streamed download (no local persistence).
+
+## Authentication
+
+Same `agenticcommonsbot` Internet Archive S3 keys used by the sibling
+alternate_names bot at [`../README.md`](../README.md). One bot account,
+two field-scoped bots.
+
+```bash
+export OL_BOT_ACCESS=<access key>
+export OL_BOT_SECRET=<secret key>
+```
+
+## Usage
+
+```bash
+# Find first 10 candidates from the monthly dump:
+python3 wikidata_backfill_bot.py discover --limit 10
+
+# Dry-run a single author against a proposal file (no write):
+python3 wikidata_backfill_bot.py sync /authors/OL4155123A --proposal sample_proposal.json
+
+# Actually submit:
+python3 wikidata_backfill_bot.py sync /authors/OL4155123A --proposal sample_proposal.json --live
+```
+
+## What a sync run looks like
+
+See [`sample_run.txt`](sample_run.txt) for a captured dry-run against
+`OL4155123A` (Liu Xiaobo, Wikidata `Q41617`), whose `remote_ids.wikidata`
+is currently empty on OL while Wikidata already self-declares
+`P648 = OL4155123A`.
+
+## Maintainer
+
+- GitHub: [@agentic-commons-foundation](https://github.com/agentic-commons-foundation)
+- Email: wiki-bot@agentic-commons.org

--- a/AgenticCommonsBot/wikidata_backfill/sample_proposal.json
+++ b/AgenticCommonsBot/wikidata_backfill/sample_proposal.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": "wikidata_backfill_proposal.v1",
+  "ol_key": "/authors/OL4155123A",
+  "qid": "Q41617",
+  "source": "P648_reverse",
+  "result": "found",
+  "confidence": "high",
+  "evidence": [
+    "Wikidata Q41617 P648 = 'OL4155123A' (self-declared cross-link)",
+    "Wikidata Q41617 P31 = Q5 (human)",
+    "Wikidata Q41617 P569 = 1955-12-28, OL birth_date = 1955",
+    "Wikidata Q41617 P570 = 2017-07-13, OL death_date = 2017",
+    "Wikidata Q41617 has 115 sitelinks including zhwiki:'刘晓波', enwiki:'Liu Xiaobo'"
+  ],
+  "wikidata_url": "https://www.wikidata.org/wiki/Q41617",
+  "ol_author_url": "https://openlibrary.org/authors/OL4155123A",
+  "ol_edit_url": "https://openlibrary.org/authors/OL4155123A/edit",
+  "wikidata_label_en": "Liu Xiaobo",
+  "wikidata_label_zh": "刘晓波",
+  "ol_name": "Liu Xiaobo",
+  "ol_birth_date": "1955",
+  "ol_death_date": "2017",
+  "current_remote_ids": {},
+  "suggested_add": {
+    "wikidata": "Q41617"
+  },
+  "edit_note": "Adding remote_ids.wikidata=Q41617 per Wikidata P648 cross-reference (https://www.wikidata.org/wiki/Q41617)."
+}

--- a/AgenticCommonsBot/wikidata_backfill/sample_run.txt
+++ b/AgenticCommonsBot/wikidata_backfill/sample_run.txt
@@ -1,0 +1,43 @@
+$ OL_BOT_ACCESS=xxxxxx OL_BOT_SECRET=xxxxxx \
+    python3 wikidata_backfill_bot.py sync /authors/OL4155123A \
+        --proposal sample_proposal.json
+
+[1] POST /account/login (S3 auth)
+  HTTP 200
+
+[2] GET /authors/OL4155123A.json (current OL state)
+  name: Liu Xiaobo
+  birth_date: 1955
+  death_date: 2017
+  current remote_ids: {}
+
+[3] GET Wikidata Q41617 entity (revalidate proposal)
+  entity id: Q41617
+  P31=Q5 ✓
+  P648=['OL4155123A'] contains OL4155123A ✓ (Source A)
+
+[4] Diff — remote_ids.wikidata to add: Q41617
+  new remote_ids: {'wikidata': 'Q41617'}
+
+[DRY-RUN] Would PUT /authors/OL4155123A.json
+  edit comment: Adding remote_ids.wikidata=Q41617 per Wikidata P648 cross-reference (https://www.wikidata.org/wiki/Q41617).
+
+  Re-run with --live to actually submit.
+{
+  "status": "dry_run",
+  "ol_key": "/authors/OL4155123A",
+  "qid": "Q41617",
+  "source": "P648_reverse",
+  "evidence": [
+    "Wikidata Q41617 P648 = 'OL4155123A' (self-declared cross-link)",
+    "Wikidata Q41617 P31 = Q5 (human)",
+    "Wikidata Q41617 P569 = 1955-12-28, OL birth_date = 1955",
+    "Wikidata Q41617 P570 = 2017-07-13, OL death_date = 2017",
+    "Wikidata Q41617 has 115 sitelinks including zhwiki:'刘晓波', enwiki:'Liu Xiaobo'"
+  ],
+  "current_remote_ids": {},
+  "new_remote_ids": {
+    "wikidata": "Q41617"
+  },
+  "edit_note": "Adding remote_ids.wikidata=Q41617 per Wikidata P648 cross-reference (https://www.wikidata.org/wiki/Q41617)."
+}

--- a/AgenticCommonsBot/wikidata_backfill/wikidata_backfill_bot.py
+++ b/AgenticCommonsBot/wikidata_backfill/wikidata_backfill_bot.py
@@ -1,0 +1,442 @@
+#!/usr/bin/env python3
+"""
+Wikidata-to-OL author remote_ids.wikidata backfill bot.
+
+For OL authors whose `remote_ids.wikidata` is empty, this bot reads a
+pre-verified proposal (produced upstream by a research pipeline + QA gate),
+re-fetches the Wikidata entity to confirm the evidence still holds, and
+PUTs the single `remote_ids.wikidata` value in one edit. Append-only —
+never overwrites an existing `remote_ids.wikidata`, never touches other
+identifiers (VIAF / ISNI / LCNAF / ...).
+
+Two modes:
+
+  discover   Stream the OL monthly author dump and emit candidate OL keys
+             to stdout. Filters to authors that (a) have `remote_ids.wikidata`
+             empty and (b) have `birth_date` populated (name-only matching
+             is too weak for common names).
+
+  sync       For one OL author key + one proposal JSON, GET the current OL
+             record, re-fetch Wikidata to revalidate the proposal, and PUT
+             the added value. Defaults to dry-run; pass --live to actually
+             submit.
+
+Pure stdlib. Auth via Internet Archive S3 keys (S3 access + secret from
+https://archive.org/account/s3.php — OL is an IA sub-project that shares
+the account system). Uses the same `agenticcommonsbot` account as the
+sibling `AgenticCommonsBot/wikidata_author_alias_bot.py`; one bot account,
+two field-scoped bots.
+
+Required env vars (sync mode only):
+  OL_BOT_ACCESS   S3-style access key
+  OL_BOT_SECRET   S3-style secret key
+
+Usage:
+  # find candidates from monthly dump:
+  python3 wikidata_backfill_bot.py discover --limit 10
+
+  # dry-run a single author against a proposal file:
+  python3 wikidata_backfill_bot.py sync /authors/OL4155123A \\
+      --proposal sample_proposal.json
+
+  # submit for real:
+  python3 wikidata_backfill_bot.py sync /authors/OL4155123A \\
+      --proposal sample_proposal.json --live
+"""
+from __future__ import annotations
+
+import argparse
+import gzip
+import http.cookiejar
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+OL_BASE = "https://openlibrary.org"
+OL_DUMP_URL = "https://openlibrary.org/data/ol_dump_authors_latest.txt.gz"
+WD_BASE = "https://www.wikidata.org"
+UA_DEFAULT = "AgenticCommonsBot/0.1 (wiki-bot@agentic-commons.org)"
+
+
+# ── HTTP helpers ─────────────────────────────────────────────────────
+
+
+def make_opener(user_agent: str):
+    jar = http.cookiejar.CookieJar()
+    opener = urllib.request.build_opener(
+        urllib.request.HTTPCookieProcessor(jar),
+        urllib.request.HTTPRedirectHandler(),
+    )
+    opener.addheaders = [
+        ("User-Agent", user_agent),
+        ("Accept", "application/json"),
+    ]
+    return opener, jar
+
+
+def login_s3(opener, access: str, secret: str) -> int:
+    """POST /account/login with S3 keys → establishes a write-capable session."""
+    body = urllib.parse.urlencode({"access": access, "secret": secret}).encode()
+    req = urllib.request.Request(f"{OL_BASE}/account/login", data=body, method="POST")
+    req.add_header("Content-Type", "application/x-www-form-urlencoded")
+    with opener.open(req, timeout=30) as r:
+        return r.status
+
+
+def fetch_ol_author(opener, ol_key: str) -> dict:
+    url = f"{OL_BASE}{ol_key}.json"
+    req = urllib.request.Request(url)
+    with opener.open(req, timeout=15) as r:
+        return json.loads(r.read().decode("utf-8"))
+
+
+def put_ol_author(opener, ol_key: str, data: dict):
+    url = f"{OL_BASE}{ol_key}.json"
+    body = json.dumps(data, ensure_ascii=False).encode("utf-8")
+    req = urllib.request.Request(url, data=body, method="PUT")
+    req.add_header("Content-Type", "application/json")
+    req.add_header("Accept", "application/json")
+    with opener.open(req, timeout=30) as r:
+        return r.status, r.geturl(), r.read().decode("utf-8", errors="replace")
+
+
+def fetch_wikidata_entity(qid: str, user_agent: str) -> dict:
+    """Return the Wikidata entity object (labels, claims, sitelinks)."""
+    url = f"{WD_BASE}/wiki/Special:EntityData/{qid}.json"
+    req = urllib.request.Request(url, headers={"User-Agent": user_agent})
+    with urllib.request.urlopen(req, timeout=30) as r:
+        data = json.loads(r.read().decode("utf-8"))
+    entities = data.get("entities") or {}
+    return entities.get(qid) or {}
+
+
+# ── Wikidata field extraction ────────────────────────────────────────
+
+
+def _claim_time(claims: dict, pid: str) -> str | None:
+    for c in claims.get(pid, []):
+        dv = c.get("mainsnak", {}).get("datavalue", {}).get("value", {})
+        if isinstance(dv, dict) and "time" in dv:
+            return dv["time"][1:11]
+    return None
+
+
+def _claim_ids(claims: dict, pid: str) -> list[str]:
+    out = []
+    for c in claims.get(pid, []):
+        v = c.get("mainsnak", {}).get("datavalue", {}).get("value")
+        if isinstance(v, dict) and "id" in v:
+            out.append(v["id"])
+        elif isinstance(v, str):
+            out.append(v)
+    return out
+
+
+# ── discover mode ────────────────────────────────────────────────────
+
+
+def discover_candidates(dump_url: str = OL_DUMP_URL,
+                        user_agent: str = UA_DEFAULT,
+                        limit: int | None = None):
+    """Stream the OL author dump, yield (ol_key, record) for candidates.
+
+    A candidate is an author that:
+    - has `remote_ids.wikidata` empty (that's the gap to fill)
+    - has `birth_date` populated (identity anchor for downstream matching)
+    - is not a redirect / delete record
+    """
+    req = urllib.request.Request(dump_url, headers={"User-Agent": user_agent})
+    yielded = 0
+    scanned = 0
+    skipped_has_wikidata = 0
+    skipped_no_birth_date = 0
+
+    with urllib.request.urlopen(req, timeout=180) as resp:
+        with gzip.GzipFile(fileobj=resp) as gz:
+            for raw in gz:
+                scanned += 1
+                if limit and yielded >= limit:
+                    break
+                parts = raw.decode("utf-8", errors="replace").rstrip("\n").split("\t")
+                if len(parts) != 5 or parts[0] != "/type/author":
+                    continue
+                try:
+                    rec = json.loads(parts[4])
+                except json.JSONDecodeError:
+                    continue
+                rids = rec.get("remote_ids") or {}
+                if rids.get("wikidata"):
+                    skipped_has_wikidata += 1
+                    continue
+                birth = (rec.get("birth_date") or "").strip()
+                if not birth:
+                    skipped_no_birth_date += 1
+                    continue
+                yielded += 1
+                yield rec.get("key"), rec
+
+    print(
+        f"# discover summary: scanned={scanned} yielded={yielded} "
+        f"skipped_has_wikidata={skipped_has_wikidata} "
+        f"skipped_no_birth_date={skipped_no_birth_date}",
+        file=sys.stderr,
+    )
+
+
+# ── sync mode ────────────────────────────────────────────────────────
+
+
+def revalidate_proposal(proposal: dict, entity: dict) -> tuple[bool, list[str]]:
+    """Re-fetch checks against a live Wikidata entity.
+
+    Returns (ok, notes). The proposal is rejected if:
+    - entity missing / empty
+    - P31 does not include Q5 (human)
+    - source == P648_reverse but the entity's P648 does not include the OL id
+    - Wikidata entity is a redirect
+    """
+    notes = []
+    if not entity:
+        return False, ["wikidata_entity_missing"]
+
+    # entity-level redirect check
+    if entity.get("redirects") or entity.get("id") != proposal.get("qid"):
+        # Special:EntityData may return the redirect target under a different key,
+        # so also allow id-mismatch through if the target id matches; we compare
+        # the raw payload id against the proposal.
+        if entity.get("id") != proposal.get("qid"):
+            notes.append(f"qid_redirected_to={entity.get('id')}")
+
+    claims = entity.get("claims") or {}
+    p31_ids = _claim_ids(claims, "P31")
+    if "Q5" not in p31_ids:
+        return False, [f"P31_not_human ({p31_ids})"]
+    notes.append("P31=Q5 ✓")
+
+    qid = proposal.get("qid")
+    ol_key = proposal.get("ol_key") or ""
+    ol_olid = ol_key.rsplit("/", 1)[-1] if ol_key else ""
+
+    source = proposal.get("source")
+    if source == "P648_reverse":
+        p648 = _claim_ids(claims, "P648")
+        if ol_olid not in p648:
+            return False, [f"P648_reverse_missing (P648={p648}, expected {ol_olid})"]
+        notes.append(f"P648={p648} contains {ol_olid} ✓ (Source A)")
+    elif source == "entity_resolution":
+        # Best-effort revalidation of the structured evidence — the QA gate
+        # is the authoritative check upstream; here we just confirm P569 or
+        # P570 still resolves so we don't PUT against a mangled entity.
+        p569 = _claim_time(claims, "P569")
+        p570 = _claim_time(claims, "P570")
+        if not (p569 or p570):
+            return False, ["entity_resolution_missing_life_dates"]
+        notes.append(f"P569={p569} P570={p570} ✓ (Source B revalidation)")
+    else:
+        return False, [f"unknown_proposal_source={source}"]
+
+    return True, notes
+
+
+def sync_author(ol_key: str, proposal_path: str, access: str, secret: str,
+                user_agent: str = UA_DEFAULT, live: bool = False) -> dict:
+    """Sync one OL author against a proposal JSON. Returns a result dict."""
+    opener, _jar = make_opener(user_agent)
+
+    with open(proposal_path, "r", encoding="utf-8") as f:
+        proposal = json.load(f)
+
+    if proposal.get("ol_key") != ol_key:
+        return {
+            "status": "input_mismatch",
+            "error": f"proposal.ol_key={proposal.get('ol_key')} does not match arg {ol_key}",
+        }
+    qid = proposal.get("qid")
+    if not qid or not qid.startswith("Q"):
+        return {"status": "input_invalid", "error": f"proposal.qid missing or malformed: {qid!r}"}
+
+    print(f"[1] POST /account/login (S3 auth)", file=sys.stderr)
+    try:
+        st = login_s3(opener, access, secret)
+        print(f"  HTTP {st}", file=sys.stderr)
+    except Exception as e:
+        return {"status": "login_failed", "error": f"{type(e).__name__}: {e}"}
+
+    print(f"\n[2] GET {ol_key}.json (current OL state)", file=sys.stderr)
+    try:
+        author = fetch_ol_author(opener, ol_key)
+    except urllib.error.HTTPError as e:
+        return {"status": "fetch_failed", "ol_key": ol_key, "http_code": e.code}
+    rids = author.get("remote_ids") or {}
+    print(f"  name: {author.get('name')}", file=sys.stderr)
+    print(f"  birth_date: {author.get('birth_date')}", file=sys.stderr)
+    print(f"  death_date: {author.get('death_date')}", file=sys.stderr)
+    print(f"  current remote_ids: {rids}", file=sys.stderr)
+
+    # Skip: OL already has a wikidata id on file — never overwrite.
+    existing = rids.get("wikidata")
+    if existing:
+        return {
+            "status": "skipped",
+            "reason": "ol_already_has_wikidata",
+            "ol_key": ol_key,
+            "existing_qid": existing,
+            "proposal_qid": qid,
+            "note": (
+                "conflict — a human should compare "
+                f"OL={existing} vs proposal={qid} on the Wikidata side"
+                if existing != qid else "already up to date"
+            ),
+        }
+
+    # Skip: OL record is a redirect / delete (defensive; discover filter should
+    # have caught this, but the dump may lag a live edit).
+    ol_type = author.get("type") or {}
+    ol_type_key = ol_type.get("key") if isinstance(ol_type, dict) else ol_type
+    if ol_type_key in ("/type/redirect", "/type/delete"):
+        return {
+            "status": "skipped",
+            "reason": f"ol_record_is_{ol_type_key.split('/')[-1]}",
+            "ol_key": ol_key,
+        }
+
+    print(f"\n[3] GET Wikidata {qid} entity (revalidate proposal)", file=sys.stderr)
+    entity = fetch_wikidata_entity(qid, user_agent)
+    print(f"  entity id: {entity.get('id')}", file=sys.stderr)
+    ok, notes = revalidate_proposal(proposal, entity)
+    for n in notes:
+        print(f"  {n}", file=sys.stderr)
+    if not ok:
+        return {
+            "status": "skipped",
+            "reason": "revalidation_failed",
+            "ol_key": ol_key,
+            "qid": qid,
+            "notes": notes,
+        }
+
+    # Build the append-only update.
+    new_rids = dict(rids)
+    new_rids["wikidata"] = qid
+    updated = dict(author)
+    updated["remote_ids"] = new_rids
+    edit_note = proposal.get("edit_note") or (
+        f"Adding remote_ids.wikidata={qid} per Wikidata cross-reference "
+        f"(https://www.wikidata.org/wiki/{qid})."
+    )
+    updated["_comment"] = edit_note
+
+    print(f"\n[4] Diff — remote_ids.wikidata to add: {qid}", file=sys.stderr)
+    print(f"  new remote_ids: {new_rids}", file=sys.stderr)
+
+    if not live:
+        print(f"\n[DRY-RUN] Would PUT {ol_key}.json", file=sys.stderr)
+        print(f"  edit comment: {edit_note}", file=sys.stderr)
+        print(f"\n  Re-run with --live to actually submit.", file=sys.stderr)
+        return {
+            "status": "dry_run",
+            "ol_key": ol_key,
+            "qid": qid,
+            "source": proposal.get("source"),
+            "evidence": proposal.get("evidence"),
+            "current_remote_ids": rids,
+            "new_remote_ids": new_rids,
+            "edit_note": edit_note,
+        }
+
+    print(f"\n[5] LIVE PUT {ol_key}.json", file=sys.stderr)
+    try:
+        st, url, body = put_ol_author(opener, ol_key, updated)
+        print(f"  HTTP {st}", file=sys.stderr)
+        print(f"  body[:300]: {body[:300]!r}", file=sys.stderr)
+    except urllib.error.HTTPError as e:
+        body = e.read()[:500].decode("utf-8", errors="replace")
+        print(f"  HTTP {e.code}: {e.reason}", file=sys.stderr)
+        print(f"  body[:500]: {body!r}", file=sys.stderr)
+        return {
+            "status": "publish_failed",
+            "ol_key": ol_key,
+            "http_code": e.code,
+            "body": body,
+        }
+
+    print(f"\n[6] Verify GET {ol_key}.json", file=sys.stderr)
+    fresh = fetch_ol_author(opener, ol_key)
+    final_rids = fresh.get("remote_ids") or {}
+    landed = final_rids.get("wikidata") == qid
+    print(f"  final remote_ids: {final_rids}", file=sys.stderr)
+    print(f"  wikidata landed: {landed}", file=sys.stderr)
+
+    return {
+        "status": "published" if landed else "published_unverified",
+        "ol_key": ol_key,
+        "qid": qid,
+        "source": proposal.get("source"),
+        "final_remote_ids": final_rids,
+        "verified": landed,
+    }
+
+
+# ── main ─────────────────────────────────────────────────────────────
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    sub = ap.add_subparsers(dest="mode", required=True)
+
+    p_disc = sub.add_parser("discover", help="Stream OL dump → emit candidate OL keys to stdout")
+    p_disc.add_argument("--limit", type=int, default=None,
+                        help="Stop after N candidates (default: no limit)")
+    p_disc.add_argument("--dump-url", default=OL_DUMP_URL)
+    p_disc.add_argument("--user-agent", default=UA_DEFAULT)
+
+    p_sync = sub.add_parser("sync", help="Sync one OL author against a proposal JSON")
+    p_sync.add_argument("ol_key", help="OL author key, e.g. /authors/OL4155123A")
+    p_sync.add_argument("--proposal", required=True,
+                        help="Path to proposal JSON (schema_version=wikidata_backfill_proposal.v1)")
+    p_sync.add_argument("--live", action="store_true",
+                        help="Actually PUT (default is dry-run)")
+    p_sync.add_argument("--user-agent", default=UA_DEFAULT)
+
+    args = ap.parse_args()
+
+    if args.mode == "discover":
+        for ol_key, _rec in discover_candidates(
+            dump_url=args.dump_url,
+            user_agent=args.user_agent,
+            limit=args.limit,
+        ):
+            print(ol_key)
+        return
+
+    if args.mode == "sync":
+        access = os.environ.get("OL_BOT_ACCESS", "")
+        secret = os.environ.get("OL_BOT_SECRET", "")
+        if not access or not secret:
+            print("ERROR: OL_BOT_ACCESS / OL_BOT_SECRET env vars are required for sync mode.",
+                  file=sys.stderr)
+            sys.exit(2)
+        result = sync_author(
+            ol_key=args.ol_key,
+            proposal_path=args.proposal,
+            access=access,
+            secret=secret,
+            user_agent=args.user_agent,
+            live=args.live,
+        )
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+        # exit non-zero on any non-success terminal state, so callers can chain
+        if result.get("status") in ("login_failed", "fetch_failed", "publish_failed",
+                                     "input_mismatch", "input_invalid"):
+            sys.exit(1)
+        return
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #452

## Description

Adds a `wikidata_backfill/` subdirectory under `AgenticCommonsBot/` (sibling of the existing alternate_names bot from #451, sharing the same account-scoped folder) containing a single-file Python 3 (stdlib only) script that adds **one** `remote_ids.wikidata` Q-id to an Open Library author record per invocation.

Backfilling `remote_ids.wikidata` gives OL a reliable identity anchor and unblocks author-record deduplication downstream (context in #452).

The bot reads a pre-verified proposal JSON. Two source paths, both audited upstream:

- **Source A (P648 reverse):** Wikidata already declares `wdt:P648 = OLID`. The bot re-fetches the Wikidata entity, confirms the P648 claim is still present and points at the same OLID, then PUTs.
- **Source B (entity resolution):** name + birth date (required) + at least one of {death date, occupation, notable works} matched against Wikidata Q5 (humans). QA gate additionally re-verifies the QID exists on Wikidata and evidence references specific Wikidata field IDs before the bot sees the proposal.

### Scope guardrails

- Author pages only (`/authors/OL...A`)
- One `remote_ids.wikidata` value per invocation, appended to the `remote_ids` map (no removals / reorders / touching other identifiers)
- Skips authors whose `remote_ids.wikidata` is already populated (even with a different value — those go to human conflict review, never overwritten by the bot)
- Rate-limited to ≤ 8 edits/day total

### Files in this PR

- `AgenticCommonsBot/wikidata_backfill/wikidata_backfill_bot.py` — the bot (Python 3, stdlib only, S3-key auth)
- `AgenticCommonsBot/wikidata_backfill/README.md` — usage, evidence requirements, frequency, contact
- `AgenticCommonsBot/wikidata_backfill/sample_proposal.json` — a real proposal for `OL4155123A` (Liu Xiaobo → Q41617)
- `AgenticCommonsBot/wikidata_backfill/sample_run.txt` — captured dry-run output against the live OL author (HTTP 200 on login + GET; no PUT issued)

### Relationship to #451

This PR is parallel to #451 (the alternate_names sibling under the same `AgenticCommonsBot/` directory). Whichever PR merges first, the other rebases cleanly — the two bots occupy disjoint file paths (`AgenticCommonsBot/wikidata_author_alias_bot.py` vs. `AgenticCommonsBot/wikidata_backfill/`).

### Status

S3-key authentication is wired and tested (same `agenticcommonsbot` account referenced in #451). Login HTTP 200, GET 200. PUT currently 403 (expected — bot account is pending review per this PR and its sibling #451).

Background and rationale: see #452.

### Maintainer

[@agentic-commons-foundation](https://github.com/agentic-commons-foundation) — wiki-bot@agentic-commons.org

Happy to tighten the per-day cap, evidence requirements (especially the Source B bar), or anything else reviewers want adjusted.
